### PR TITLE
Fixes Set handling in filterWhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,38 @@
 
 A dynamic SOQL query & SOSL search library for Salesforce Apex
 
-## Unlocked Package - no namespace - v3.1.1
+## Unlocked Package - no namespace - v3.1.2
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsMOQA0)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsMOQA0)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsbQQAS)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsbQQAS)
 
 Install with SF CLI:
 
 ```shell
-sf package install --apex-compile package --wait 20 --security-type AdminsOnly --package 04t5Y000001TsMOQA0
+sf package install --apex-compile package --wait 20 --security-type AdminsOnly --package 04t5Y000001TsbQQAS
 ```
 
 Install with SFDX CLI:
 
 ```shell
-sfdx force:package:install --apexcompile package --wait 20 --securitytype AdminsOnly --package 04t5Y000001TsMOQA0
+sfdx force:package:install --apexcompile package --wait 20 --securitytype AdminsOnly --package 04t5Y000001TsbQQAS
 ```
 
-## Unlocked Package - `Nebula` namespace - v3.1.1
+## Unlocked Package - `Nebula` namespace - v3.1.2
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsMTQA0)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsMTQA0)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsbVQAS)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001TsbVQAS)
 
 Install with SF CLI:
 
 ```shell
-sf package install --apex-compile package --wait 20 --security-type AdminsOnly --package 04t5Y000001TsMTQA0
+sf package install --apex-compile package --wait 20 --security-type AdminsOnly --package 04t5Y000001TsbVQAS
 ```
 
 Install with SFDX CLI:
 
 ```shell
-sfdx force:package:install --apexcompile package --wait 20 --securitytype AdminsOnly --package 04t5Y000001TsMTQA0
+sfdx force:package:install --apexcompile package --wait 20 --securitytype AdminsOnly --package 04t5Y000001TsbVQAS
 ```
 
 ## Features

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -202,7 +202,7 @@ global class AggregateQuery extends SOQL {
       super.doGetLimitCountString() +
       super.doGetOffetString();
 
-    System.debug(LoggingLevel.FINEST, this.query);
+    System.debug(System.LoggingLevel.FINEST, this.query);
     return this.query;
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -332,7 +332,7 @@ global class Query extends SOQL {
     // If additional builder methods are later called, the builder methods will set hasChanged = true
     this.hasChanged = false;
 
-    System.debug(LoggingLevel.FINEST, this.query);
+    System.debug(System.LoggingLevel.FINEST, this.query);
     return this.query;
   }
 
@@ -361,7 +361,7 @@ global class Query extends SOQL {
       super.doGetLimitCountString() +
       ')';
 
-    System.debug(LoggingLevel.FINEST, childQuery);
+    System.debug(System.LoggingLevel.FINEST, childQuery);
     return childQuery;
   }
 
@@ -378,7 +378,7 @@ global class Query extends SOQL {
       super.doGetLimitCountString() +
       ')';
 
-    System.debug(LoggingLevel.FINEST, subquery);
+    System.debug(System.LoggingLevel.FINEST, subquery);
     return subquery;
   }
 
@@ -391,7 +391,7 @@ global class Query extends SOQL {
 
     String searchQuery = this.getSObjectType() + sobjectTypeOptions;
 
-    System.debug(LoggingLevel.FINEST, searchQuery);
+    System.debug(System.LoggingLevel.FINEST, searchQuery);
     return searchQuery;
   }
 

--- a/nebula-query-and-search/main/classes/Query.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/Query.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/RecordSearch.cls
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls
@@ -94,7 +94,7 @@ global class RecordSearch extends SOSL {
     // If additional builder methods are later called, the builder methods will set hasChanged = true
     this.hasChanged = false;
 
-    System.debug(LoggingLevel.FINEST, this.searchQuery);
+    System.debug(System.LoggingLevel.FINEST, this.searchQuery);
     return this.searchQuery;
   }
 

--- a/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -410,7 +410,7 @@ global abstract class SOQL implements Comparable {
     private final String isoCurrency;
 
     public IsoCurrency(String isoCode, Decimal currencyAmount) {
-      if (!UserInfo.isMultiCurrencyOrganization()) {
+      if (!System.UserInfo.isMultiCurrencyOrganization()) {
         throw new SOQLException('IsoCurrency is only supported in multi-currency orgs');
       }
       this.isoCurrency = isoCode + currencyAmount;
@@ -522,7 +522,7 @@ global abstract class SOQL implements Comparable {
       Integer lastFieldIndex = fields.size() - 1;
       List<String> queryFieldPieces = new List<String>();
       for (Integer i = 0; i < fields.size(); i++) {
-        SObjectField field = fields[i];
+        Schema.SObjectField field = fields[i];
         // If any field in the chain is not accessible, then the user cant access the data, so return an empty list
         if (!field.getDescribe().isAccessible()) {
           return null;

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -620,7 +620,7 @@ global abstract class SOQL implements Comparable {
       if (valueToFormat == null) {
         return null;
       } else if (valueToFormat instanceof Iterable<Object>) {
-        return this.convertListToQueryString((Iterable<Object>) valueToFormat);
+        return this.convertIterableToQueryString((Iterable<Object>) valueToFormat);
       } else if (valueToFormat instanceof Map<Object, Object>) {
         return this.convertMapToQueryString(valueToFormat);
       } else if (valueToFormat instanceof Date) {
@@ -651,7 +651,7 @@ global abstract class SOQL implements Comparable {
       return input;
     }
 
-    private String convertListToQueryString(Iterable<Object> valueIterable) {
+    private String convertIterableToQueryString(Iterable<Object> valueIterable) {
       List<String> parsedValueList = new List<String>();
       Iterator<Object> valueIterator = valueIterable.iterator();
       while (valueIterator.hasNext()) {
@@ -661,18 +661,9 @@ global abstract class SOQL implements Comparable {
       return '(' + String.join(parsedValueList, ', ') + ')';
     }
 
-    private String convertSetToQueryString(Object valueSet) {
-      String unformattedString = String.valueOf(valueSet).replace('{', '').replace('}', '');
-      List<String> parsedValueList = new List<String>();
-      for (String collectionItem : unformattedString.split(',')) {
-        parsedValueList.add(this.formatObjectForQueryString(collectionItem));
-      }
-      return '(' + String.join(parsedValueList, ', ') + ')';
-    }
-
     private String convertMapToQueryString(Object valueMap) {
       Map<String, Object> untypedMap = (Map<String, Object>) Json.deserializeUntyped(Json.serialize(valueMap));
-      return this.convertSetToQueryString(untypedMap.keySet());
+      return this.convertIterableToQueryString(untypedMap.keySet());
     }
   }
 }

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -619,10 +619,8 @@ global abstract class SOQL implements Comparable {
     private String formatObjectForQueryString(Object valueToFormat) {
       if (valueToFormat == null) {
         return null;
-      } else if (valueToFormat instanceof List<Object>) {
-        return this.convertListToQueryString((List<Object>) valueToFormat);
-      } else if (valueToFormat instanceof Set<Object>) {
-        return this.convertSetToQueryString(valueToFormat);
+      } else if (valueToFormat instanceof Iterable<Object>) {
+        return this.convertListToQueryString((Iterable<Object>) valueToFormat);
       } else if (valueToFormat instanceof Map<Object, Object>) {
         return this.convertMapToQueryString(valueToFormat);
       } else if (valueToFormat instanceof Date) {
@@ -653,9 +651,11 @@ global abstract class SOQL implements Comparable {
       return input;
     }
 
-    private String convertListToQueryString(List<Object> valueList) {
+    private String convertListToQueryString(Iterable<Object> valueIterable) {
       List<String> parsedValueList = new List<String>();
-      for (Object value : valueList) {
+      Iterator<Object> valueIterator = valueIterable.iterator();
+      while (valueIterator.hasNext()) {
+        Object value = valueIterator.next();
         parsedValueList.add(this.formatObjectForQueryString(value));
       }
       return '(' + String.join(parsedValueList, ', ') + ')';

--- a/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -59,13 +59,13 @@ private class AggregateQuery_Tests {
   static void it_should_cache_results() {
     AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType);
     aggregateQuery.cacheResults();
-    System.assertEquals(0, Limits.getQueries());
+    System.assertEquals(0, System.Limits.getQueries());
 
     for (Integer i = 0; i < 3; i++) {
       aggregateQuery.getResults();
     }
 
-    System.assertEquals(1, Limits.getQueries());
+    System.assertEquals(1, System.Limits.getQueries());
   }
 
   @IsTest

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -43,11 +43,11 @@ private class Query_Tests {
       ' AND LastModifiedDate <= ' +
       now.format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'', 'Greenwich Mean Time') +
       ' AND Profile.Id != \'' +
-      UserInfo.getProfileId() +
+      System.UserInfo.getProfileId() +
       '\'' +
       ' ORDER BY Profile.CreatedBy.LastModifiedDate ASC NULLS FIRST, Name ASC NULLS FIRST, Email ASC NULLS FIRST' +
       ' LIMIT 100 OFFSET 1 FOR VIEW';
-    List<SObjectField> fieldsToQuery = new List<SObjectField>{ Schema.User.IsActive, Schema.User.Alias };
+    List<Schema.SObjectField> fieldsToQuery = new List<Schema.SObjectField>{ Schema.User.IsActive, Schema.User.Alias };
 
     Query userQuery = new Query(Schema.User.SObjectType)
       .addFields(fieldsToQuery)
@@ -59,7 +59,7 @@ private class Query_Tests {
       .includeFormattedValues()
       .usingScope(SOQL.Scope.MINE)
       .filterWhere(Schema.User.IsActive, SOQL.Operator.EQUALS, true)
-      .filterWhere(new SOQL.QueryField(Schema.User.SObjectType, 'Profile.Id'), SOQL.Operator.NOT_EQUAL_TO, UserInfo.getProfileId())
+      .filterWhere(new SOQL.QueryField(Schema.User.SObjectType, 'Profile.Id'), SOQL.Operator.NOT_EQUAL_TO, System.UserInfo.getProfileId())
       .filterWhere(Schema.User.LastModifiedDate, SOQL.Operator.LESS_THAN_OR_EQUAL_TO, now)
       .filterWhere(Schema.User.LastLoginDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, new SOQL.DateLiteral(SOQL.RelativeDateLiteral.LAST_N_DAYS, 3))
       .filterWhere(Schema.User.CreatedDate, SOQL.Operator.LESS_THAN_OR_EQUAL_TO, new SOQL.DateLiteral(SOQL.FixedDateLiteral.LAST_WEEK))
@@ -130,7 +130,7 @@ private class Query_Tests {
       ' END' +
       ' FROM Task';
 
-    Test.startTest();
+    System.Test.startTest();
 
     Map<Schema.SObjectType, List<Schema.SObjectField>> fieldsBySObjectType = new Map<Schema.SObjectType, List<Schema.SObjectField>>();
 
@@ -145,7 +145,7 @@ private class Query_Tests {
     // Query the task object
     Query taskQuery = new Query(Schema.Task.SObjectType).addPolymorphicFields(Schema.Task.WhoId, fieldsBySObjectType);
 
-    Test.stopTest();
+    System.Test.stopTest();
 
     System.assertEquals(expectedQuery, taskQuery.getQuery());
   }
@@ -244,7 +244,7 @@ private class Query_Tests {
   @IsTest
   static void it_should_return_results_when_filtering_with_iso_currency() {
     // If multi-currency isn't enabled, then we cannot use IsoCurrency, so skip running this test
-    if (!UserInfo.isMultiCurrencyOrganization()) {
+    if (!System.UserInfo.isMultiCurrencyOrganization()) {
       return;
     }
 
@@ -261,20 +261,20 @@ private class Query_Tests {
     Query userQuery = new Query(Schema.User.SObjectType).limitTo(1);
 
     // First, verify that caching is not enabled by default
-    System.assertEquals(0, Limits.getQueries());
+    System.assertEquals(0, System.Limits.getQueries());
     for (Integer i = 0; i < loops; i++) {
       userQuery.getResults();
     }
-    System.assertEquals(loops, Limits.getQueries());
+    System.assertEquals(loops, System.Limits.getQueries());
 
-    Test.startTest();
+    System.Test.startTest();
 
     userQuery.cacheResults();
     for (Integer i = 0; i < loops; i++) {
       userQuery.getResults();
     }
-    System.assertEquals(1, Limits.getQueries());
+    System.assertEquals(1, System.Limits.getQueries());
 
-    Test.stopTest();
+    System.Test.stopTest();
   }
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -19,6 +19,18 @@ private class Query_Tests {
   }
 
   @IsTest
+  static void it_should_correctly_represent_sets_in_query_filters() {
+    String expectedName = 'someName';
+    String expectedQueryString = 'SELECT Id, Name FROM Account WHERE Name IN (\'' + expectedName + '\')';
+
+    String actualQuery = new Query(Schema.Account.SObjectType)
+      .filterWhere(Schema.Account.Name, SOQL.Operator.IS_IN, new Set<String>{ expectedName })
+      .getQuery();
+
+    System.Assert.areEqual(expectedQueryString, actualQuery);
+  }
+
+  @IsTest
   static void it_should_return_results_for_an_advanced_query() {
     Datetime now = System.now();
     String expectedQueryString =

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls
+++ b/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls
@@ -10,10 +10,10 @@
 private class RecordSearch_Tests {
   @IsTest
   static void it_should_return_first_result_for_a_single_sobject_type() {
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)';
 
     Query userQuery = new Query(Schema.User.SObjectType);
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), userQuery);
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), userQuery);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
     User userSearchResult = (User) userSearch.getFirstResult();
@@ -21,10 +21,10 @@ private class RecordSearch_Tests {
 
   @IsTest
   static void it_should_return_results_for_a_single_sobject_type() {
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)';
 
     Query userQuery = new Query(Schema.User.SObjectType);
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), userQuery);
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), userQuery);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
     List<User> userSearchResults = userSearch.getFirstResults();
@@ -32,10 +32,10 @@ private class RecordSearch_Tests {
 
   @IsTest
   static void it_should_return_results_for_multiple_sobject_types() {
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING Account(Id, Name), User(Id, Name)';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING Account(Id, Name), User(Id, Name)';
 
     List<Query> queries = new List<Query>{ new Query(Schema.User.SObjectType), new Query(Schema.Account.SObjectType) };
-    RecordSearch search = new RecordSearch(UserInfo.getUserEmail(), queries);
+    RecordSearch search = new RecordSearch(System.UserInfo.getUserEmail(), queries);
 
     System.assertEquals(expectedSearchQueryString, search.getSearch());
     List<List<SObject>> searchResults = search.getResults();
@@ -43,9 +43,9 @@ private class RecordSearch_Tests {
 
   @IsTest
   static void it_should_return_results_with_highlight_enabled() {
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name) WITH HIGHLIGHT';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name) WITH HIGHLIGHT';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.withHighlight();
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -57,13 +57,13 @@ private class RecordSearch_Tests {
     Integer snippetTargetLength = 10;
     String expectedSearchQueryString =
       'FIND \'' +
-      UserInfo.getUserEmail() +
+      System.UserInfo.getUserEmail() +
       '\' IN ALL FIELDS RETURNING User(Id, Name)' +
       ' WITH SNIPPET (target_length=' +
       snippetTargetLength +
       ')';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.withSnippet(snippetTargetLength);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -73,9 +73,9 @@ private class RecordSearch_Tests {
   @IsTest
   static void it_should_return_results_in_email_search_group() {
     Integer snippetTargetLength = 10;
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN EMAIL FIELDS RETURNING User(Id, Name)';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN EMAIL FIELDS RETURNING User(Id, Name)';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.inSearchGroup(SOSL.SearchGroup.EMAIL_FIELDS);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -84,9 +84,9 @@ private class RecordSearch_Tests {
 
   @IsTest
   static void it_should_return_results_with_spell_correction_enabled() {
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' WITH SPELL_CORRECTION = true';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' WITH SPELL_CORRECTION = true';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.withSpellCorrection();
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -101,9 +101,9 @@ private class RecordSearch_Tests {
     }
 
     // If Knowledge is enabled, then execute the test
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' UPDATE TRACKING';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' UPDATE TRACKING';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.updateArticleReporting(SOSL.ArticleReporting.TRACKING);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -118,9 +118,9 @@ private class RecordSearch_Tests {
     }
 
     // If Knowledge is enabled, then execute the test
-    String expectedSearchQueryString = 'FIND \'' + UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' UPDATE VIEWSTAT';
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING User(Id, Name)' + ' UPDATE VIEWSTAT';
 
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), new Query(Schema.User.SObjectType));
     userSearch.updateArticleReporting(SOSL.ArticleReporting.VIEWSTAT);
 
     System.assertEquals(expectedSearchQueryString, userSearch.getSearch());
@@ -131,23 +131,23 @@ private class RecordSearch_Tests {
   static void it_should_cache_search_results_when_enabled() {
     Integer loops = 4;
     Query userQuery = new Query(Schema.User.SObjectType);
-    RecordSearch userSearch = new RecordSearch(UserInfo.getUserEmail(), userQuery);
+    RecordSearch userSearch = new RecordSearch(System.UserInfo.getUserEmail(), userQuery);
 
     // First, verify that caching is not enabled by default
-    System.assertEquals(0, Limits.getSoslQueries());
+    System.assertEquals(0, System.Limits.getSoslQueries());
     for (Integer i = 0; i < loops; i++) {
       userSearch.getResults();
     }
-    System.assertEquals(loops, Limits.getSoslQueries());
+    System.assertEquals(loops, System.Limits.getSoslQueries());
 
-    Test.startTest();
+    System.Test.startTest();
 
     userSearch.cacheResults();
     for (Integer i = 0; i < loops; i++) {
       userSearch.getResults();
     }
-    System.assertEquals(1, Limits.getSoslQueries());
+    System.assertEquals(1, System.Limits.getSoslQueries());
 
-    Test.stopTest();
+    System.Test.stopTest();
   }
 }

--- a/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-query-and-search",
-  "version": "3.2.0",
+  "version": "3.1.2",
   "description": "A dynamic SOQL query & SOSL search library for Salesforce Apex",
   "devDependencies": {
     "@cparra/apexdocs": "^2.14.0",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,7 +13,7 @@
       "package": "Nebula Query & Search (Nebula namespace)",
       "path": "nebula-query-and-search",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-      "versionNumber": "3.1.1.0",
+      "versionNumber": "3.1.2.0",
       "versionName": "Fixes Set handling in Query.filterWhere()",
       "versionDescription": "Fixed an bug in `Query.filterWhere()` when filtering on `Set<T>` that would previously result in an invalid query being generated",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaQueryAndSearch/releases",
@@ -23,7 +23,7 @@
       "package": "Nebula Query & Search (no namespace)",
       "path": "nebula-query-and-search",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-      "versionNumber": "3.1.1.0",
+      "versionNumber": "3.1.2.0",
       "versionName": "Fixes Set handling in Query.filterWhere()",
       "versionDescription": "Fixed an bug in `Query.filterWhere()` when filtering on `Set<T>` that would previously result in an invalid query being generated",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaQueryAndSearch/releases",
@@ -33,7 +33,9 @@
   "packageAliases": {
     "Nebula Query & Search (Nebula namespace)": "0Ho5Y000000fxvvSAA",
     "Nebula Query & Search (Nebula namespace)@3.1.1": "04t5Y000001TsMTQA0",
+    "Nebula Query & Search (Nebula namespace)@3.1.2": "04t5Y000001TsbVQAS",
     "Nebula Query & Search (no namespace)": "0Ho5Y000000blOESAY",
-    "Nebula Query & Search (no namespace)@3.1.1": "04t5Y000001TsMOQA0"
+    "Nebula Query & Search (no namespace)@3.1.1": "04t5Y000001TsMOQA0",
+    "Nebula Query & Search (no namespace)@3.1.2": "04t5Y000001TsbQQAS"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,7 +2,7 @@
   "name": "Nebula Query & Search",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "57.0",
+  "sourceApiVersion": "58.0",
   "plugins": {
     "sfdx-plugin-prettier": {
       "enabled": true
@@ -14,8 +14,8 @@
       "path": "nebula-query-and-search",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "versionNumber": "3.1.1.0",
-      "versionName": "New unlocked package release",
-      "versionDescription": "Initial release of new unlocked package",
+      "versionName": "Fixes Set handling in Query.filterWhere()",
+      "versionDescription": "Fixed an bug in `Query.filterWhere()` when filtering on `Set<T>` that would previously result in an invalid query being generated",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaQueryAndSearch/releases",
       "default": false
     },
@@ -24,8 +24,8 @@
       "path": "nebula-query-and-search",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "versionNumber": "3.1.1.0",
-      "versionName": "New unlocked package release",
-      "versionDescription": "Initial release of new unlocked package",
+      "versionName": "Fixes Set handling in Query.filterWhere()",
+      "versionDescription": "Fixed an bug in `Query.filterWhere()` when filtering on `Set<T>` that would previously result in an invalid query being generated",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaQueryAndSearch/releases",
       "default": true
     }


### PR DESCRIPTION
*Fixes #43 by upgrading SOQl.cls to API version 58, where Set<T> always implements Iterable<T> to simplify string joining for Set operators