### PR TITLE
Added ability to auto-generate bind variable keys and specify filter logic

### DIFF
--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -303,7 +303,7 @@ global class AggregateQuery extends SOQL {
   }
 
   private AggregateQuery setHasChanged() {
-    this.hasChanged = true;
+    this.doSetHasChanged();
     return this;
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -361,4 +361,29 @@ global class AggregateQuery extends SOQL {
       return aggregateFunction.name() + '(' + fieldApiName + ') ' + fieldAlias;
     }
   }
+
+  global class AggregateQueryFilter extends SOQL.QueryFilter {
+    private SOQL.Aggregate aggregateFunction;
+
+    public AggregateQueryFilter(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindKey)
+    {
+        super(queryField, operator, value, bindKey);
+        this.aggregateFunction = aggregateFunction;
+    }
+
+    public override String toString()
+    {
+        return String.format(
+          '{0}({1}) {2} {3}',
+          new List<String> {
+          this.aggregateFunction.name(),
+          this.queryField.toString(),
+          SOQL.getOperatorValue(this.operator),
+          (String.isNotBlank(this.bindKey) ? ':' + this.bindKey : new QueryArgument(this.value).toString())
+          }
+        );
+    }
+
+  }
+
 }

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -85,7 +85,7 @@ global class AggregateQuery extends SOQL {
   }
 
   global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value) {
-    return this.havingAggregate(aggregateFunction, queryField, operator, value, null);
+    return this.havingAggregate(aggregateFunction, queryField, operator, value, this.generateNextBindVariableKey());
   }
 
   global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -99,7 +99,7 @@ global class AggregateQuery extends SOQL {
   }
 
   global AggregateQuery orHavingAggregate(List<AggregateQueryFilter> filters) {
-    this.havingClauseFilterLogic = this.doOrFilter(this.havingClauseFilters, this.havingClauseFilterLogic);
+    this.havingClauseFilterLogic = this.doOrFilter(filters, this.havingClauseFilters, this.havingClauseFilterLogic);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -136,8 +136,8 @@ global class AggregateQuery extends SOQL {
     return this.setHasChanged();
   }
 
-  global AggregateQuery withAccessLevel(System.AccessLevel mode) {
-    super.doWithAccessLevel(mode);
+  global AggregateQuery withAccessLevel(System.AccessLevel accessLevel) {
+    super.doWithAccessLevel(accessLevel);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -221,6 +221,11 @@ global class AggregateQuery extends SOQL {
     return this.setHasChanged();
   }
 
+  global AggregateQuery generateBindVariableKeys() {
+    super.doGenerateBindVariableKeys();
+    return this;
+  }
+
   // TODO decide if this should be global
   public AggregateQuery cacheResults() {
     super.doCacheResults();

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -346,49 +346,7 @@ global class AggregateQuery extends SOQL {
   }
 
   private String getHavingString() {
-    List<String> havingConditionStrings = new List<String>();
-    for (AggregateQueryFilter condition : this.havingConditions)
-    {
-        condition.setBindKey(condition.getBindKey() ?? this.generateNextBindVariableKey());
-        if (String.isNotBlank(condition.getBindKey())) {
-          this.bindsMap.put(condition.getBindKey(), condition.getValue());
-        }
-        havingConditionStrings.add(condition.toString());
-    }
-    if (String.isBlank(this.havingConditionsLogic))
-    {
-        return '';
-    }
-
-    List<String> havingConditionsLogicParts = this.havingConditionsLogic.split('\\s+');
-    List<String> havingConditionsLogicPartsReplaced = new List<String>();
-    for (String havingConditionsLogicPart : havingConditionsLogicParts)
-    {
-        Matcher m = Pattern.compile('\\d+').matcher(havingConditionsLogicPart);
-        Boolean indexFound = m.find();
-        if (indexFound)
-        {
-            Integer havingConditionsIndex = Integer.valueOf(m.group());
-            try
-            {
-                havingConditionsLogicPartsReplaced.add(
-                    havingConditionsLogicPart.replace(
-                        m.group(),
-                        havingConditionStrings[havingConditionsIndex - 1]
-                    )
-                );
-            }
-            catch (ListException e)
-            {
-                throw new QueryException('No query HAVING filter defined for index "' + havingConditionsIndex + '" specified in filter conditions "' + this.havingConditionsLogic + '"');
-            }
-        }
-        else
-        {
-            havingConditionsLogicPartsReplaced.add(havingConditionsLogicPart);
-        }
-    }
-    return ' HAVING ' + String.join(havingConditionsLogicPartsReplaced, ' ');
+    return this.doGetFilterableClauseString('HAVING', this.havingConditions, this.havingConditionsLogic);
   }
 
   private class AggregateField {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -15,14 +15,16 @@
 global class AggregateQuery extends SOQL {
   private SOQL.GroupingDimension groupingDimension;
   private List<AggregateField> aggregateFields;
-  private List<String> havingConditions;
+  private List<AggregateQueryFilter> havingConditions;
+  protected String havingConditionsLogic;
   private String countQuery;
 
   global AggregateQuery(Schema.SObjectType sobjectType) {
     super(sobjectType, false);
 
     this.aggregateFields = new List<AggregateField>();
-    this.havingConditions = new List<String>();
+    this.havingConditions = new List<AggregateQueryFilter>();
+    this.havingConditionsLogic = '';
   }
 
   global AggregateQuery groupByField(Schema.SObjectField field) {
@@ -90,19 +92,26 @@ global class AggregateQuery extends SOQL {
 
   global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {
     this.havingConditions.add(
-      String.format(
-        '{0}({1}) {2} {3}',
-        new List<String> {
-          aggregateFunction.name(),
-          queryField.toString(),
-          SOQL.getOperatorValue(operator),
-          (String.isNotBlank(bindWithKey) ? ':' + bindWithKey : new QueryArgument(value).toString())
-        }
-      )
+        new AggregateQueryFilter(aggregateFunction, queryField, operator, value, bindWithKey)
     );
-    if (String.isNotBlank(bindWithKey)) {
-      this.bindsMap.put(bindWithKey, value);
+    this.havingConditionsLogic += (this.havingConditions.size() == 1 ? '1' : ' AND ' + this.havingConditions.size());
+    return this.setHasChanged();
+  }
+
+  global AggregateQuery havingOrAggregate(List<AggregateQueryFilter> filters) {
+    if (filters?.isEmpty() != false) {
+      return this;
     }
+
+    filters.sort();
+
+    this.havingConditionsLogic += (this.havingConditions.isEmpty() ? '' : ' AND ') + '(';
+    for (Integer i = 0; i < filters.size(); i++) {
+        AggregateQueryFilter filter = filters[i];
+        this.havingConditions.add(filter);
+        this.havingConditionsLogic += (i == 0 ? '' : ' OR ') + this.havingConditions.size();
+    }
+    this.havingConditionsLogic += ')';
     return this.setHasChanged();
   }
 
@@ -337,7 +346,49 @@ global class AggregateQuery extends SOQL {
   }
 
   private String getHavingString() {
-    return this.havingConditions.isEmpty() ? '' : ' HAVING ' + String.join(this.havingConditions, ', ');
+    List<String> havingConditionStrings = new List<String>();
+    for (AggregateQueryFilter condition : this.havingConditions)
+    {
+        condition.setBindKey(condition.getBindKey() ?? this.generateNextBindVariableKey());
+        if (String.isNotBlank(condition.getBindKey())) {
+          this.bindsMap.put(condition.getBindKey(), condition.getValue());
+        }
+        havingConditionStrings.add(condition.toString());
+    }
+    if (String.isBlank(this.havingConditionsLogic))
+    {
+        return '';
+    }
+
+    List<String> havingConditionsLogicParts = this.havingConditionsLogic.split('\\s+');
+    List<String> havingConditionsLogicPartsReplaced = new List<String>();
+    for (String havingConditionsLogicPart : havingConditionsLogicParts)
+    {
+        Matcher m = Pattern.compile('\\d+').matcher(havingConditionsLogicPart);
+        Boolean indexFound = m.find();
+        if (indexFound)
+        {
+            Integer havingConditionsIndex = Integer.valueOf(m.group());
+            try
+            {
+                havingConditionsLogicPartsReplaced.add(
+                    havingConditionsLogicPart.replace(
+                        m.group(),
+                        havingConditionStrings[havingConditionsIndex - 1]
+                    )
+                );
+            }
+            catch (ListException e)
+            {
+                throw new QueryException('No query HAVING filter defined for index "' + havingConditionsIndex + '" specified in filter conditions "' + this.havingConditionsLogic + '"');
+            }
+        }
+        else
+        {
+            havingConditionsLogicPartsReplaced.add(havingConditionsLogicPart);
+        }
+    }
+    return ' HAVING ' + String.join(havingConditionsLogicPartsReplaced, ' ');
   }
 
   private class AggregateField {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -106,6 +106,11 @@ global class AggregateQuery extends SOQL {
     return this.setHasChanged();
   }
 
+  global AggregateQuery withAccessLevel(System.AccessLevel mode) {
+    super.doWithAccessLevel(mode);
+    return this.setHasChanged();
+  }
+
   global AggregateQuery orderByField(Schema.SObjectField field) {
     return this.orderByField(field, null);
   }
@@ -220,7 +225,7 @@ global class AggregateQuery extends SOQL {
       super.doGetOrderByString() +
       super.doGetLimitCountString() +
       super.doGetOffetString();
-    return Database.countQuery(countQuery);
+    return Database.countQuery(countQuery, this.doGetAccessLevel());
   }
 
   global AggregateResult getFirstResult() {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -99,19 +99,7 @@ global class AggregateQuery extends SOQL {
   }
 
   global AggregateQuery orHavingAggregate(List<AggregateQueryFilter> filters) {
-    if (filters?.isEmpty() != false) {
-      return this;
-    }
-
-    filters.sort();
-
-    this.havingClauseFilterLogic += (this.havingClauseFilters.isEmpty() ? '' : ' AND ') + '(';
-    for (Integer i = 0; i < filters.size(); i++) {
-        AggregateQueryFilter filter = filters[i];
-        this.havingClauseFilters.add(filter);
-        this.havingClauseFilterLogic += (i == 0 ? '' : ' OR ') + this.havingClauseFilters.size();
-    }
-    this.havingClauseFilterLogic += ')';
+    this.havingClauseFilterLogic = this.doOrFilter(this.havingClauseFilters, this.havingClauseFilterLogic);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -15,16 +15,16 @@
 global class AggregateQuery extends SOQL {
   private SOQL.GroupingDimension groupingDimension;
   private List<AggregateField> aggregateFields;
-  private List<AggregateQueryFilter> havingConditions;
-  protected String havingConditionsLogic;
+  private List<AggregateQueryFilter> havingClauseFilters;
+  protected String havingClauseFilterLogic;
   private String countQuery;
 
   global AggregateQuery(Schema.SObjectType sobjectType) {
     super(sobjectType, false);
 
     this.aggregateFields = new List<AggregateField>();
-    this.havingConditions = new List<AggregateQueryFilter>();
-    this.havingConditionsLogic = '';
+    this.havingClauseFilters = new List<AggregateQueryFilter>();
+    this.havingClauseFilterLogic = '';
   }
 
   global AggregateQuery groupByField(Schema.SObjectField field) {
@@ -91,27 +91,27 @@ global class AggregateQuery extends SOQL {
   }
 
   global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {
-    this.havingConditions.add(
+    this.havingClauseFilters.add(
         new AggregateQueryFilter(aggregateFunction, queryField, operator, value, bindWithKey)
     );
-    this.havingConditionsLogic += (this.havingConditions.size() == 1 ? '1' : ' AND ' + this.havingConditions.size());
+    this.havingClauseFilterLogic += (this.havingClauseFilters.size() == 1 ? '1' : ' AND ' + this.havingClauseFilters.size());
     return this.setHasChanged();
   }
 
-  global AggregateQuery havingOrAggregate(List<AggregateQueryFilter> filters) {
+  global AggregateQuery orHavingAggregate(List<AggregateQueryFilter> filters) {
     if (filters?.isEmpty() != false) {
       return this;
     }
 
     filters.sort();
 
-    this.havingConditionsLogic += (this.havingConditions.isEmpty() ? '' : ' AND ') + '(';
+    this.havingClauseFilterLogic += (this.havingClauseFilters.isEmpty() ? '' : ' AND ') + '(';
     for (Integer i = 0; i < filters.size(); i++) {
         AggregateQueryFilter filter = filters[i];
-        this.havingConditions.add(filter);
-        this.havingConditionsLogic += (i == 0 ? '' : ' OR ') + this.havingConditions.size();
+        this.havingClauseFilters.add(filter);
+        this.havingClauseFilterLogic += (i == 0 ? '' : ' OR ') + this.havingClauseFilters.size();
     }
-    this.havingConditionsLogic += ')';
+    this.havingClauseFilterLogic += ')';
     return this.setHasChanged();
   }
 
@@ -266,7 +266,7 @@ global class AggregateQuery extends SOQL {
       super.doGetUsingScopeString() +
       super.doGetWhereClauseString() +
       this.getGroupByString() +
-      this.getHavingString() +
+      this.getHavingClauseString() +
       super.doGetOrderByString() +
       super.doGetLimitCountString() +
       super.doGetOffetString();
@@ -287,7 +287,7 @@ global class AggregateQuery extends SOQL {
       super.doGetUsingScopeString() +
       super.doGetWhereClauseString() +
       this.getGroupByString() +
-      this.getHavingString() +
+      this.getHavingClauseString() +
       super.doGetOrderByString() +
       super.doGetLimitCountString() +
       super.doGetOffetString();
@@ -345,8 +345,8 @@ global class AggregateQuery extends SOQL {
     return String.isEmpty(queryFieldString) ? '' : groupByTextString + queryFieldString + groupingDimensionClosingString;
   }
 
-  private String getHavingString() {
-    return this.doGetFilterableClauseString('HAVING', this.havingConditions, this.havingConditionsLogic);
+  private String getHavingClauseString() {
+    return this.doGetFilterableClauseString('HAVING', this.havingClauseFilters, this.havingClauseFilterLogic);
   }
 
   private class AggregateField {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -16,6 +16,7 @@ global class AggregateQuery extends SOQL {
   private SOQL.GroupingDimension groupingDimension;
   private List<AggregateField> aggregateFields;
   private List<String> havingConditions;
+  private String countQuery;
 
   global AggregateQuery(Schema.SObjectType sobjectType) {
     super(sobjectType, false);
@@ -79,8 +80,29 @@ global class AggregateQuery extends SOQL {
     return this.havingAggregate(aggregateFunction, new SOQL.QueryField(field), operator, value);
   }
 
+  global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, Schema.SObjectField field, SOQL.Operator operator, Object value, String bindWithKey) {
+    return this.havingAggregate(aggregateFunction, new SOQL.QueryField(field), operator, value, bindWithKey);
+  }
+
   global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value) {
-    this.havingConditions.add(aggregateFunction.name() + '(' + queryField + ') ' + SOQL.getOperatorValue(operator) + ' ' + value);
+    return this.havingAggregate(aggregateFunction, queryField, operator, value, null);
+  }
+
+  global AggregateQuery havingAggregate(SOQL.Aggregate aggregateFunction, SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {
+    this.havingConditions.add(
+      String.format(
+        '{0}({1}) {2} {3}',
+        new List<String> {
+          aggregateFunction.name(),
+          queryField.toString(),
+          SOQL.getOperatorValue(operator),
+          (String.isNotBlank(bindWithKey) ? ':' + bindWithKey : new QueryArgument(value).toString())
+        }
+      )
+    );
+    if (String.isNotBlank(bindWithKey)) {
+      this.bindsMap.put(bindWithKey, value);
+    }
     return this.setHasChanged();
   }
 
@@ -88,8 +110,16 @@ global class AggregateQuery extends SOQL {
     return this.filterWhere(new SOQL.QueryField(field), operator, value);
   }
 
+  global AggregateQuery filterWhere(Schema.SObjectField field, SOQL.Operator operator, Object value, String bindWithKey) {
+    return this.filterWhere(new SOQL.QueryField(field), operator, value, bindWithKey);
+  }
+
   global AggregateQuery filterWhere(SOQL.QueryField queryField, SOQL.Operator operator, Object value) {
     return this.filterWhere(new SOQL.QueryFilter(queryField, operator, value));
+  }
+
+  global AggregateQuery filterWhere(SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {
+    return this.filterWhere(new SOQL.QueryFilter(queryField, operator, value, bindWithKey));
   }
 
   global AggregateQuery filterWhere(SOQL.QueryFilter filter) {
@@ -171,6 +201,26 @@ global class AggregateQuery extends SOQL {
     return this.setHasChanged();
   }
 
+  global AggregateQuery setBind(String key, Object value) {
+    super.doSetBind(key, value);
+    return this.setHasChanged();
+  }
+
+  global AggregateQuery setBinds(Map<String, Object> binds) {
+    super.doSetBinds(binds);
+    return this.setHasChanged();
+  }
+
+  global AggregateQuery removeBind(String key) {
+    super.doRemoveBind(key);
+    return this.setHasChanged();
+  }
+
+  global AggregateQuery clearBinds() {
+    super.doClearBinds();
+    return this.setHasChanged();
+  }
+
   // TODO decide if this should be global
   public AggregateQuery cacheResults() {
     super.doCacheResults();
@@ -211,10 +261,12 @@ global class AggregateQuery extends SOQL {
     return this.query;
   }
 
-  // TODO consider renaming to getCountResult()
-  @SuppressWarnings('PMD.ApexSOQLInjection')
-  global Integer getResultCount() {
-    String countQuery =
+  global String getCountQuery() {
+    if (this.countQuery != null && !this.hasChanged) {
+      return this.countQuery;
+    }
+
+    this.countQuery =
       'SELECT COUNT()' +
       ' FROM ' +
       this.sobjectType +
@@ -225,7 +277,19 @@ global class AggregateQuery extends SOQL {
       super.doGetOrderByString() +
       super.doGetLimitCountString() +
       super.doGetOffetString();
-    return Database.countQuery(countQuery, this.doGetAccessLevel());
+
+    System.debug(System.LoggingLevel.FINEST, this.countQuery);
+    return this.countQuery;
+  }
+
+  // TODO consider renaming to getCountResult()
+  @SuppressWarnings('PMD.ApexSOQLInjection')
+  global Integer getResultCount() {
+    return Database.countQueryWithBinds(
+      this.getCountQuery(),
+      this.doGetBindsMap(),
+      this.doGetAccessLevel()
+    );
   }
 
   global AggregateResult getFirstResult() {

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls
@@ -103,6 +103,11 @@ global class AggregateQuery extends SOQL {
     return this.setHasChanged();
   }
 
+  global AggregateQuery setHavingFilterLogic(String filterLogic) {
+    this.havingClauseFilterLogic = filterLogic;
+    return this.setHasChanged();
+  }
+
   global AggregateQuery filterWhere(Schema.SObjectField field, SOQL.Operator operator, Object value) {
     return this.filterWhere(new SOQL.QueryField(field), operator, value);
   }
@@ -130,6 +135,11 @@ global class AggregateQuery extends SOQL {
 
   global AggregateQuery orFilterWhere(List<SOQL.QueryFilter> filters) {
     super.doOrFilterWhere(filters);
+    return this.setHasChanged();
+  }
+
+  global AggregateQuery setWhereFilterLogic(String filterLogic) {
+    super.doSetWhereFilterLogic(filterLogic);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/AggregateQuery.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -450,7 +450,7 @@ global class Query extends SOQL {
   }
 
   private Query setHasChanged() {
-    this.hasChanged = true;
+    this.doSetHasChanged();
     return this;
   }
 

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -239,6 +239,11 @@ global class Query extends SOQL {
   //return this.setHasChanged();
   //}
 
+  global Query withAccessLevel(System.AccessLevel mode) {
+    super.doWithAccessLevel(mode);
+    return this.setHasChanged();
+  }
+
   global Query orderByField(Schema.SObjectField field) {
     return this.orderByField(new SOQL.QueryField(field));
   }

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -225,6 +225,11 @@ global class Query extends SOQL {
     return this.setHasChanged();
   }
 
+  global Query setWhereFilterLogic(String filterLogic) {
+    super.doSetWhereFilterLogic(filterLogic);
+    return this.setHasChanged();
+  }
+
   //global Query filterWhereInSubquery(Schema.SObjectType childSObjectType, Schema.SObjectField lookupFieldOnChildSObject) {
   //this.whereFilters.add('Id IN (SELECT ' + lookupFieldOnChildSObject + ' FROM ' + childSObjectType + ')');
   //return this.setHasChanged();

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -199,8 +199,16 @@ global class Query extends SOQL {
     return this.filterWhere(new SOQL.QueryField(field), operator, value);
   }
 
+  global Query filterWhere(Schema.SObjectField field, SOQL.Operator operator, Object value, String bindWithKey) {
+    return this.filterWhere(new SOQL.QueryField(field), operator, value, bindWithKey);
+  }
+
   global Query filterWhere(SOQL.QueryField queryField, SOQL.Operator operator, Object value) {
     return this.filterWhere(new SOQL.QueryFilter(queryField, operator, value));
+  }
+
+  global Query filterWhere(SOQL.QueryField queryField, SOQL.Operator operator, Object value, String bindWithKey) {
+    return this.filterWhere(new SOQL.QueryFilter(queryField, operator, value, bindWithKey));
   }
 
   global Query filterWhere(SOQL.QueryFilter filter) {
@@ -291,6 +299,26 @@ global class Query extends SOQL {
 
   global Query forView() {
     this.forView = true;
+    return this.setHasChanged();
+  }
+
+  global Query setBind(String key, Object value) {
+    super.doSetBind(key, value);
+    return this.setHasChanged();
+  }
+
+  global Query setBinds(Map<String, Object> binds) {
+    super.doSetBinds(binds);
+    return this.setHasChanged();
+  }
+
+  global Query removeBind(String key) {
+    super.doRemoveBind(key);
+    return this.setHasChanged();
+  }
+
+  global Query clearBinds() {
+    super.doClearBinds();
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -322,6 +322,11 @@ global class Query extends SOQL {
     return this.setHasChanged();
   }
 
+  global Query generateBindVariableKeys() {
+    super.doGenerateBindVariableKeys();
+    return this;
+  }
+
   // TODO decide if this should be global
   public Query cacheResults() {
     super.doCacheResults();

--- a/nebula-query-and-search/main/classes/Query.cls
+++ b/nebula-query-and-search/main/classes/Query.cls
@@ -247,8 +247,8 @@ global class Query extends SOQL {
   //return this.setHasChanged();
   //}
 
-  global Query withAccessLevel(System.AccessLevel mode) {
-    super.doWithAccessLevel(mode);
+  global Query withAccessLevel(System.AccessLevel accessLevel) {
+    super.doWithAccessLevel(accessLevel);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/Query.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/Query.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/Query.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/Query.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/RecordSearch.cls
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls
@@ -64,6 +64,11 @@ global class RecordSearch extends SOSL {
     return this.setHasChanged();
   }
 
+  global RecordSearch withAccessLevel(System.AccessLevel accessLevel) {
+    this.accessLevel = accessLevel;
+    return this.setHasChanged();
+  }
+
   global RecordSearch updateArticleReporting(SOSL.ArticleReporting articleReporting) {
     this.articleReporting = articleReporting;
     return this.setHasChanged();

--- a/nebula-query-and-search/main/classes/RecordSearch.cls
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls
@@ -65,7 +65,7 @@ global class RecordSearch extends SOSL {
   }
 
   global RecordSearch withAccessLevel(System.AccessLevel accessLevel) {
-    this.accessLevel = accessLevel;
+    super.doWithAccessLevel(accessLevel);
     return this.setHasChanged();
   }
 

--- a/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/RecordSearch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -265,25 +265,25 @@ global abstract class SOQL implements Comparable {
     }
   }
 
-  protected String doOrFilter(List<SOQL.QueryFilter> filters, String filterLogic) {
-    if (filters?.isEmpty() != false) {
+  protected String doOrFilter(List<SOQL.QueryFilter> newFilters, List<SOQL.QueryFilter> clauseFilters, String filterLogic) {
+    if (newFilters?.isEmpty() != false) {
       return filterLogic;
     }
 
-    filters.sort();
+    newFilters.sort();
 
-    filterLogic += (filters.isEmpty() ? '' : ' AND ') + '(';
-    for (Integer i = 0; i < filters.size(); i++) {
-        SOQL.QueryFilter filter = filters[i];
-        filters.add(filter);
-        filterLogic += (i == 0 ? '' : ' OR ') + filters.size();
+    filterLogic += (clauseFilters.isEmpty() ? '' : ' AND ') + '(';
+    for (Integer i = 0; i < newFilters.size(); i++) {
+        SOQL.QueryFilter filter = newFilters[i];
+        clauseFilters.add(filter);
+        filterLogic += (i == 0 ? '' : ' OR ') + clauseFilters.size();
     }
     filterLogic += ')';
     return filterLogic;
   }
 
   protected void doOrFilterWhere(List<SOQL.QueryFilter> filters) {
-    this.whereClauseFilterLogic = this.doOrFilter(this.whereClauseFilters, this.whereClauseFilterLogic);
+    this.whereClauseFilterLogic = this.doOrFilter(filters, this.whereClauseFilters, this.whereClauseFilterLogic);
   }
 
   protected void doWithAccessLevel(System.AccessLevel accessLevel) {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -322,10 +322,21 @@ global abstract class SOQL implements Comparable {
 
   protected void doRemoveBind(String key) {
     this.bindsMap.remove(key);
+    for (QueryFilter filter : this.whereFilters)
+    {
+      if (filter.bindKey == key)
+      {
+        filter.bindKey = null;
+      }
+    }
   }
 
   protected void doClearBinds() {
     this.bindsMap.clear();
+    for (QueryFilter filter : this.whereFilters)
+    {
+      filter.bindKey = null;
+    }
   }
 
   protected void doGenerateBindVariableKeys() {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -411,50 +411,54 @@ global abstract class SOQL implements Comparable {
     return this.scope == null ? '' : ' USING SCOPE ' + this.scope.name();
   }
 
-  protected String doGetWhereClauseString() {
-    List<String> whereFilterStrings = new List<String>();
-    for (QueryFilter filter : this.whereFilters)
+  protected String doGetFilterableClauseString(String clause, LIST<SOQL.QueryFilter> filters, String filterLogic) {
+    List<String> filterStrings = new List<String>();
+    for (Soql.QueryFilter filter : filters)
     {
         filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
-        if (String.isNotBlank(filter.bindKey)) {
-          this.bindsMap.put(filter.bindKey, filter.value);
+        if (String.isNotBlank(filter.getBindKey())) {
+          this.bindsMap.put(filter.getBindKey(), filter.getValue());
         }
-        whereFilterStrings.add(filter.toString());
+        filterStrings.add(filter.toString());
     }
-    if (String.isBlank(this.whereFilterConditionsString))
+    if (String.isBlank(filterLogic))
     {
         return '';
     }
 
-    List<String> whereFilterConditionsParts = this.whereFilterConditionsString.split('\\s+');
-    List<String> whereFilterConditionsPartsReplaced = new List<String>();
-    for (String whereFilterConditionsPart : whereFilterConditionsParts)
+    List<String> filterLogicParts = filterLogic.split('\\s+');
+    List<String> filterLogicPartsReplaced = new List<String>();
+    for (String filterLogicPart : filterLogicParts)
     {
-        Matcher m = Pattern.compile('\\d+').matcher(whereFilterConditionsPart);
+        Matcher m = Pattern.compile('\\d+').matcher(filterLogicPart);
         Boolean indexFound = m.find();
         if (indexFound)
         {
-            Integer whereFilterConditionsIndex = Integer.valueOf(m.group());
+            Integer filterLogicIndex = Integer.valueOf(m.group());
             try
             {
-                whereFilterConditionsPartsReplaced.add(
-                    whereFilterConditionsPart.replace(
+                filterLogicPartsReplaced.add(
+                    filterLogicPart.replace(
                         m.group(),
-                        whereFilterStrings[whereFilterConditionsIndex - 1]
+                        filterStrings[filterLogicIndex - 1]
                     )
                 );
             }
             catch (ListException e)
             {
-                throw new QueryException('No query WHERE filter defined for index "' + whereFilterConditionsIndex + '" specified in filter conditions "' + this.whereFilterConditionsString + '"');
+                throw new QueryException('No query ' + clause + ' filter defined for index "' + filterLogicIndex + '" specified in filter conditions "' + filterLogic + '"');
             }
         }
         else
         {
-            whereFilterConditionsPartsReplaced.add(whereFilterConditionsPart);
+            filterLogicPartsReplaced.add(filterLogicPart);
         }
     }
-    return ' WHERE ' + String.join(whereFilterConditionsPartsReplaced, ' ');
+    return ' ' + clause + ' ' + String.join(filterLogicPartsReplaced, ' ');
+  }
+
+  protected String doGetWhereClauseString() {
+    return this.doGetFilterableClauseString('WHERE', this.whereFilters, this.whereFilterConditionsString);
   }
 
   protected System.AccessLevel doGetAccessLevel() {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -599,9 +599,11 @@ global abstract class SOQL implements Comparable {
     private SOQL.QueryField queryField;
     private SOQL.Operator operator;
     private Object value;
-    private String formattedValue;
-    private String filterString;
     private String bindKey;
+    private Schema.SObjectType childSObjectType;
+    private Query childQuery;
+    private Boolean inOrNotIn;
+    private Schema.SObjectField lookupFieldOnChildSObject;
 
     global QueryFilter(Schema.SObjectField field, SOQL.Operator operator, Object value) {
       this(new QueryField(field), operator, value);
@@ -619,20 +621,21 @@ global abstract class SOQL implements Comparable {
       this.queryField = queryField;
       this.operator = operator;
       this.value = value;
-      this.formattedValue = (String.isNotBlank(bindKey) ? ':' + bindKey : new QueryArgument(value).toString());
       this.bindKey = bindKey;
-
-      this.filterString = queryField + ' ' + SOQL.getOperatorValue(operator) + ' ' + formattedValue;
     }
 
     global QueryFilter(Schema.SObjectType childSObjectType, Boolean inOrNotIn, Schema.SObjectField lookupFieldOnChildSObject) {
       this.operator = inOrNotIn ? SOQL.Operator.IS_IN : SOQL.Operator.IS_NOT_IN;
-      this.filterString = 'Id ' + SOQL.getOperatorValue(this.operator) + ' (SELECT ' + lookupFieldOnChildSObject + ' FROM ' + childSObjectType + ')';
+      this.childSObjectType = childSObjectType;
+      this.inOrNotIn = inOrNotIn;
+      this.lookupFieldOnChildSObject = lookupFieldOnChildSObject;
     }
 
     global QueryFilter(Query childQuery, Boolean inOrNotIn, Schema.SObjectField lookupFieldOnChildSObject) {
       this.operator = inOrNotIn ? SOQL.Operator.IS_IN : SOQL.Operator.IS_NOT_IN;
-      this.filterString = 'Id ' + SOQL.getOperatorValue(this.operator) + ' ' + childQuery.getSubquery(lookupFieldOnChildSObject);
+      this.childQuery = childQuery;
+      this.inOrNotIn = inOrNotIn;
+      this.lookupFieldOnChildSObject = lookupFieldOnChildSObject;
     }
 
     global Integer compareTo(Object compareTo) {
@@ -659,14 +662,33 @@ global abstract class SOQL implements Comparable {
       return this.value;
     }
 
+    global String getBindKey() {
+      return this.bindKey;
+    }
+
+    global void setBindKey(String bindKey) {
+      if (this.queryField != null)
+      {
+        this.bindKey = bindKey;
+      }
+    }
+
     // TODO decide if this should be global
     public Object getFormattedValue() {
-      return this.formattedValue;
+      return (String.isNotBlank(this.bindKey) ? ':' + this.bindKey : new QueryArgument(this.value).toString());
     }
 
     // TODO decide if this should be global
     public override String toString() {
-      return this.filterString;
+      return (
+        this.queryField != null ?
+        this.queryField + ' ' + SOQL.getOperatorValue(this.operator) + ' ' + this.getFormattedValue() :
+        (
+            this.childSObjectType != null ?
+            'Id ' + SOQL.getOperatorValue(this.operator) + ' (SELECT ' + this.lookupFieldOnChildSObject + ' FROM ' + this.childSObjectType + ')' :
+            'Id ' + SOQL.getOperatorValue(this.operator) + ' ' + this.childQuery.getSubquery(this.lookupFieldOnChildSObject)
+        )
+      );
     }
   }
 

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -263,7 +263,6 @@ global abstract class SOQL implements Comparable {
       this.whereClauseFilters.add(filter);
       this.whereClauseFilterLogic += (this.whereClauseFilters.size() == 1 ? '1' : ' AND ' + this.whereClauseFilters.size());
     }
-    this.doSetHasChanged();
   }
 
   protected String doOrFilter(List<SOQL.QueryFilter> filters, String filterLogic) {
@@ -280,7 +279,6 @@ global abstract class SOQL implements Comparable {
         filterLogic += (i == 0 ? '' : ' OR ') + filters.size();
     }
     filterLogic += ')';
-    this.doSetHasChanged();
     return filterLogic;
   }
 
@@ -486,7 +484,7 @@ global abstract class SOQL implements Comparable {
     return this.bindsMap ?? new Map<String, Object>();
   }
 
-  private void doSetHasChanged() {
+  protected void doSetHasChanged() {
     this.hasChanged = true;
   }
 

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -187,7 +187,7 @@ global abstract class SOQL implements Comparable {
   protected Integer offset;
   protected Boolean hasChanged;
   protected Boolean sortQueryFields;
-
+  protected Map<String, Object> bindsMap;
   protected Boolean cacheResults;
 
   protected SOQL(Schema.SObjectType sobjectType, Boolean sortQueryFields) {
@@ -200,6 +200,7 @@ global abstract class SOQL implements Comparable {
     this.whereFilters = new List<String>();
     this.orderByFieldApiNames = new List<String>();
     this.accessLevel = System.AccessLevel.SYSTEM_MODE;
+    this.bindsMap = new Map<String, Object>();
     this.cacheResults = false;
     this.hasChanged = false;
   }
@@ -248,12 +249,15 @@ global abstract class SOQL implements Comparable {
   }
 
   protected void doFilterWhere(List<SOQL.QueryFilter> filters) {
-    if (filters == null || filters.isEmpty()) {
+    if (filters?.isEmpty() != false) {
       return;
     }
 
     for (SOQL.QueryFilter filter : filters) {
       this.whereFilters.add(filter.toString());
+      if (String.isNotBlank(filter.bindKey)) {
+        this.bindsMap.put(filter.bindKey, filter.value);
+      }
     }
     this.doSetHasChanged();
   }
@@ -302,6 +306,22 @@ global abstract class SOQL implements Comparable {
     this.offset = offset;
   }
 
+  protected void doSetBind(String key, Object value) {
+    this.bindsMap.put(key, value);
+  }
+
+  protected void doSetBinds(Map<String, Object> binds) {
+    this.bindsMap.putAll(binds);
+  }
+
+  protected void doRemoveBind(String key) {
+    this.bindsMap.remove(key);
+  }
+
+  protected void doClearBinds() {
+    this.bindsMap.clear();
+  }
+
   protected SObject doGetFirstResult() {
     List<SObject> results = this.doGetResults();
     return results == null || results.isEmpty() ? null : results[0];
@@ -311,7 +331,11 @@ global abstract class SOQL implements Comparable {
     if (this.cacheResults) {
       return this.getCachedResults();
     } else {
-      return Database.query(this.getQuery(), this.doGetAccessLevel());
+      return Database.queryWithBinds(
+        this.getQuery(),
+        this.doGetBindsMap(),
+        this.doGetAccessLevel()
+      );
     }
   }
 
@@ -383,6 +407,10 @@ global abstract class SOQL implements Comparable {
     return this.offset == null ? '' : ' OFFSET ' + this.offset;
   }
 
+  protected Map<String, Object> doGetBindsMap() {
+    return this.bindsMap ?? new Map<String, Object>();
+  }
+
   private void doSetHasChanged() {
     this.hasChanged = true;
   }
@@ -395,7 +423,11 @@ global abstract class SOQL implements Comparable {
     if (!isCached) {
       cachedResultsByHashCode.put(
         hashCode,
-        Database.query(query, this.doGetAccessLevel())
+        Database.queryWithBinds(
+          this.getQuery(),
+          this.doGetBindsMap(),
+          this.doGetAccessLevel()
+        )
       );
     }
 
@@ -555,16 +587,26 @@ global abstract class SOQL implements Comparable {
     private Object value;
     private String formattedValue;
     private String filterString;
+    private String bindKey;
 
     global QueryFilter(Schema.SObjectField field, SOQL.Operator operator, Object value) {
       this(new QueryField(field), operator, value);
     }
 
+    global QueryFilter(Schema.SObjectField field, SOQL.Operator operator, Object value, String bindKey) {
+      this(new QueryField(field), operator, value, bindKey);
+    }
+
     global QueryFilter(QueryField queryField, SOQL.Operator operator, Object value) {
+      this(queryField, operator, value, null);
+    }
+
+    global QueryFilter(QueryField queryField, SOQL.Operator operator, Object value, String bindKey) {
       this.queryField = queryField;
       this.operator = operator;
       this.value = value;
-      this.formattedValue = new QueryArgument(value).toString();
+      this.formattedValue = (String.isNotBlank(bindKey) ? ':' + bindKey : new QueryArgument(value).toString());
+      this.bindKey = bindKey;
 
       this.filterString = queryField + ' ' + SOQL.getOperatorValue(operator) + ' ' + formattedValue;
     }
@@ -618,7 +660,7 @@ global abstract class SOQL implements Comparable {
   public class SOQLException extends Exception {
   }
 
-  private class QueryArgument {
+  public class QueryArgument {
     private String value;
 
     public QueryArgument(Object valueToFormat) {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -266,21 +266,26 @@ global abstract class SOQL implements Comparable {
     this.doSetHasChanged();
   }
 
-  protected void doOrFilterWhere(List<SOQL.QueryFilter> filters) {
+  protected String doOrFilter(List<SOQL.QueryFilter> filters, String filterLogic) {
     if (filters?.isEmpty() != false) {
-      return;
+      return filterLogic;
     }
 
     filters.sort();
 
-    this.whereClauseFilterLogic += (this.whereClauseFilters.isEmpty() ? '' : ' AND ') + '(';
+    filterLogic += (filters.isEmpty() ? '' : ' AND ') + '(';
     for (Integer i = 0; i < filters.size(); i++) {
         SOQL.QueryFilter filter = filters[i];
-        this.whereClauseFilters.add(filter);
-        this.whereClauseFilterLogic += (i == 0 ? '' : ' OR ') + this.whereClauseFilters.size();
+        filters.add(filter);
+        filterLogic += (i == 0 ? '' : ' OR ') + filters.size();
     }
-    this.whereClauseFilterLogic += ')';
+    filterLogic += ')';
     this.doSetHasChanged();
+    return filterLogic;
+  }
+
+  protected void doOrFilterWhere(List<SOQL.QueryFilter> filters) {
+    this.whereClauseFilterLogic = this.doOrFilter(this.whereClauseFilters, this.whereClauseFilterLogic);
   }
 
   protected void doWithAccessLevel(System.AccessLevel accessLevel) {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -189,6 +189,8 @@ global abstract class SOQL implements Comparable {
   protected Boolean sortQueryFields;
   protected Map<String, Object> bindsMap;
   protected Boolean cacheResults;
+  private Boolean generateBindVariableKeys;
+  private Integer generatedBindVariableKeyCounter;
 
   protected SOQL(Schema.SObjectType sobjectType, Boolean sortQueryFields) {
     this.sobjectType = sobjectType;
@@ -203,6 +205,8 @@ global abstract class SOQL implements Comparable {
     this.bindsMap = new Map<String, Object>();
     this.cacheResults = false;
     this.hasChanged = false;
+    this.generateBindVariableKeys = false;
+    this.generatedBindVariableKeyCounter = 0;
   }
 
   global Schema.SObjectType getSObjectType() {
@@ -320,6 +324,14 @@ global abstract class SOQL implements Comparable {
 
   protected void doClearBinds() {
     this.bindsMap.clear();
+  }
+
+  protected void doGenerateBindVariableKeys() {
+    this.generateBindVariableKeys = true;
+  }
+
+  protected String generateNextBindVariableKey() {
+    return this.generateBindVariableKeys != true ? null : 'bindVar' + this.generatedBindVariableKeyCounter++;
   }
 
   protected SObject doGetFirstResult() {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -180,8 +180,8 @@ global abstract class SOQL implements Comparable {
   protected Map<SOQL.QueryField, SOQL.FieldCategory> includedQueryFieldsAndCategory;
   protected Set<SOQL.QueryField> excludedQueryFields;
   protected Scope scope;
-  protected List<QueryFilter> whereFilters;
-  protected String whereFilterConditionsString;
+  protected List<QueryFilter> whereClauseFilters;
+  protected String whereClauseFilterLogic;
   protected System.AccessLevel accessLevel;
   protected List<String> orderByFieldApiNames;
   protected Integer limitCount;
@@ -200,8 +200,8 @@ global abstract class SOQL implements Comparable {
     this.sobjectDescribe = this.sobjectType.getDescribe(Schema.SObjectDescribeOptions.DEFERRED);
     this.includedQueryFieldsAndCategory = new Map<SOQL.QueryField, SOQL.FieldCategory>();
     this.excludedQueryFields = new Set<SOQL.QueryField>();
-    this.whereFilters = new List<QueryFilter>();
-    this.whereFilterConditionsString = '';
+    this.whereClauseFilters = new List<QueryFilter>();
+    this.whereClauseFilterLogic = '';
     this.orderByFieldApiNames = new List<String>();
     this.accessLevel = System.AccessLevel.SYSTEM_MODE;
     this.bindsMap = new Map<String, Object>();
@@ -260,8 +260,8 @@ global abstract class SOQL implements Comparable {
     }
 
     for (SOQL.QueryFilter filter : filters) {
-      this.whereFilters.add(filter);
-      this.whereFilterConditionsString += (this.whereFilters.size() == 1 ? '1' : ' AND ' + this.whereFilters.size());
+      this.whereClauseFilters.add(filter);
+      this.whereClauseFilterLogic += (this.whereClauseFilters.size() == 1 ? '1' : ' AND ' + this.whereClauseFilters.size());
     }
     this.doSetHasChanged();
   }
@@ -273,13 +273,13 @@ global abstract class SOQL implements Comparable {
 
     filters.sort();
 
-    this.whereFilterConditionsString += (this.whereFilters.isEmpty() ? '' : ' AND ') + '(';
+    this.whereClauseFilterLogic += (this.whereClauseFilters.isEmpty() ? '' : ' AND ') + '(';
     for (Integer i = 0; i < filters.size(); i++) {
         SOQL.QueryFilter filter = filters[i];
-        this.whereFilters.add(filter);
-        this.whereFilterConditionsString += (i == 0 ? '' : ' OR ') + this.whereFilters.size();
+        this.whereClauseFilters.add(filter);
+        this.whereClauseFilterLogic += (i == 0 ? '' : ' OR ') + this.whereClauseFilters.size();
     }
-    this.whereFilterConditionsString += ')';
+    this.whereClauseFilterLogic += ')';
     this.doSetHasChanged();
   }
 
@@ -322,7 +322,7 @@ global abstract class SOQL implements Comparable {
 
   protected void doRemoveBind(String key) {
     this.bindsMap.remove(key);
-    for (QueryFilter filter : this.whereFilters)
+    for (QueryFilter filter : this.whereClauseFilters)
     {
       if (filter.bindKey == key)
       {
@@ -333,7 +333,7 @@ global abstract class SOQL implements Comparable {
 
   protected void doClearBinds() {
     this.bindsMap.clear();
-    for (QueryFilter filter : this.whereFilters)
+    for (QueryFilter filter : this.whereClauseFilters)
     {
       filter.bindKey = null;
     }
@@ -458,7 +458,7 @@ global abstract class SOQL implements Comparable {
   }
 
   protected String doGetWhereClauseString() {
-    return this.doGetFilterableClauseString('WHERE', this.whereFilters, this.whereFilterConditionsString);
+    return this.doGetFilterableClauseString('WHERE', this.whereClauseFilters, this.whereClauseFilterLogic);
   }
 
   protected System.AccessLevel doGetAccessLevel() {

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -181,6 +181,7 @@ global abstract class SOQL implements Comparable {
   protected Set<SOQL.QueryField> excludedQueryFields;
   protected Scope scope;
   protected List<String> whereFilters;
+  protected System.AccessLevel accessLevel;
   protected List<String> orderByFieldApiNames;
   protected Integer limitCount;
   protected Integer offset;
@@ -198,6 +199,7 @@ global abstract class SOQL implements Comparable {
     this.excludedQueryFields = new Set<SOQL.QueryField>();
     this.whereFilters = new List<String>();
     this.orderByFieldApiNames = new List<String>();
+    this.accessLevel = System.AccessLevel.SYSTEM_MODE;
     this.cacheResults = false;
     this.hasChanged = false;
   }
@@ -271,6 +273,10 @@ global abstract class SOQL implements Comparable {
     this.doSetHasChanged();
   }
 
+  protected void doWithAccessLevel(System.AccessLevel accessLevel) {
+    this.accessLevel = accessLevel;
+  }
+
   protected void doOrderBy(SOQL.QueryField queryField, SOQL.SortOrder sortOrder, Boolean sortNullsFirst) {
     this.doOrderBy(queryField.toString(), sortOrder, sortNullsFirst);
   }
@@ -305,7 +311,7 @@ global abstract class SOQL implements Comparable {
     if (this.cacheResults) {
       return this.getCachedResults();
     } else {
-      return Database.query(this.getQuery());
+      return Database.query(this.getQuery(), this.doGetAccessLevel());
     }
   }
 
@@ -361,6 +367,10 @@ global abstract class SOQL implements Comparable {
     return this.whereFilters.isEmpty() ? '' : ' WHERE ' + String.join(this.whereFilters, ' AND ');
   }
 
+  protected System.AccessLevel doGetAccessLevel() {
+    return this.accessLevel ?? System.AccessLevel.SYSTEM_MODE;
+  }
+
   protected String doGetOrderByString() {
     return this.orderByFieldApiNames.isEmpty() ? '' : ' ORDER BY ' + String.join(this.orderByFieldApiNames, ', ');
   }
@@ -383,7 +393,10 @@ global abstract class SOQL implements Comparable {
 
     Boolean isCached = cachedResultsByHashCode.containsKey(hashCode);
     if (!isCached) {
-      cachedResultsByHashCode.put(hashCode, Database.query(query));
+      cachedResultsByHashCode.put(
+        hashCode,
+        Database.query(query, this.doGetAccessLevel())
+      );
     }
 
     // Always return a deep clone so the original cached version is never modified

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -647,15 +647,15 @@ global abstract class SOQL implements Comparable {
     }
   }
 
-  global class QueryFilter implements Comparable {
-    private SOQL.QueryField queryField;
-    private SOQL.Operator operator;
-    private Object value;
-    private String bindKey;
-    private Schema.SObjectType childSObjectType;
-    private Query childQuery;
-    private Boolean inOrNotIn;
-    private Schema.SObjectField lookupFieldOnChildSObject;
+  global virtual class QueryFilter implements Comparable {
+    protected SOQL.QueryField queryField;
+    protected SOQL.Operator operator;
+    protected Object value;
+    protected String bindKey;
+    protected Schema.SObjectType childSObjectType;
+    protected Query childQuery;
+    protected Boolean inOrNotIn;
+    protected Schema.SObjectField lookupFieldOnChildSObject;
 
     global QueryFilter(Schema.SObjectField field, SOQL.Operator operator, Object value) {
       this(new QueryField(field), operator, value);
@@ -731,7 +731,7 @@ global abstract class SOQL implements Comparable {
     }
 
     // TODO decide if this should be global
-    public override String toString() {
+    public virtual override String toString() {
       return (
         this.queryField != null ?
         this.queryField + ' ' + SOQL.getOperatorValue(this.operator) + ' ' + this.getFormattedValue() :

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -258,6 +258,7 @@ global abstract class SOQL implements Comparable {
     }
 
     for (SOQL.QueryFilter filter : filters) {
+      filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
       this.whereFilters.add(filter.toString());
       if (String.isNotBlank(filter.bindKey)) {
         this.bindsMap.put(filter.bindKey, filter.value);
@@ -275,6 +276,7 @@ global abstract class SOQL implements Comparable {
 
     List<String> orFilterPieces = new List<String>();
     for (SOQL.QueryFilter filter : filters) {
+      filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
       orFilterPieces.add(filter.toString());
     }
     this.whereFilters.add('(' + String.join(orFilterPieces, ' OR ') + ')');

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -282,6 +282,11 @@ global abstract class SOQL implements Comparable {
     return filterLogic;
   }
 
+  protected void doSetWhereFilterLogic(String filterLogic)
+  {
+    this.whereClauseFilterLogic = filterLogic;
+  }
+
   protected void doOrFilterWhere(List<SOQL.QueryFilter> filters) {
     this.whereClauseFilterLogic = this.doOrFilter(filters, this.whereClauseFilters, this.whereClauseFilterLogic);
   }

--- a/nebula-query-and-search/main/classes/SOQL.cls
+++ b/nebula-query-and-search/main/classes/SOQL.cls
@@ -180,7 +180,8 @@ global abstract class SOQL implements Comparable {
   protected Map<SOQL.QueryField, SOQL.FieldCategory> includedQueryFieldsAndCategory;
   protected Set<SOQL.QueryField> excludedQueryFields;
   protected Scope scope;
-  protected List<String> whereFilters;
+  protected List<QueryFilter> whereFilters;
+  protected String whereFilterConditionsString;
   protected System.AccessLevel accessLevel;
   protected List<String> orderByFieldApiNames;
   protected Integer limitCount;
@@ -199,7 +200,8 @@ global abstract class SOQL implements Comparable {
     this.sobjectDescribe = this.sobjectType.getDescribe(Schema.SObjectDescribeOptions.DEFERRED);
     this.includedQueryFieldsAndCategory = new Map<SOQL.QueryField, SOQL.FieldCategory>();
     this.excludedQueryFields = new Set<SOQL.QueryField>();
-    this.whereFilters = new List<String>();
+    this.whereFilters = new List<QueryFilter>();
+    this.whereFilterConditionsString = '';
     this.orderByFieldApiNames = new List<String>();
     this.accessLevel = System.AccessLevel.SYSTEM_MODE;
     this.bindsMap = new Map<String, Object>();
@@ -258,28 +260,26 @@ global abstract class SOQL implements Comparable {
     }
 
     for (SOQL.QueryFilter filter : filters) {
-      filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
-      this.whereFilters.add(filter.toString());
-      if (String.isNotBlank(filter.bindKey)) {
-        this.bindsMap.put(filter.bindKey, filter.value);
-      }
+      this.whereFilters.add(filter);
+      this.whereFilterConditionsString += (this.whereFilters.size() == 1 ? '1' : ' AND ' + this.whereFilters.size());
     }
     this.doSetHasChanged();
   }
 
   protected void doOrFilterWhere(List<SOQL.QueryFilter> filters) {
-    if (filters == null || filters.isEmpty()) {
+    if (filters?.isEmpty() != false) {
       return;
     }
 
     filters.sort();
 
-    List<String> orFilterPieces = new List<String>();
-    for (SOQL.QueryFilter filter : filters) {
-      filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
-      orFilterPieces.add(filter.toString());
+    this.whereFilterConditionsString += (this.whereFilters.isEmpty() ? '' : ' AND ') + '(';
+    for (Integer i = 0; i < filters.size(); i++) {
+        SOQL.QueryFilter filter = filters[i];
+        this.whereFilters.add(filter);
+        this.whereFilterConditionsString += (i == 0 ? '' : ' OR ') + this.whereFilters.size();
     }
-    this.whereFilters.add('(' + String.join(orFilterPieces, ' OR ') + ')');
+    this.whereFilterConditionsString += ')';
     this.doSetHasChanged();
   }
 
@@ -401,8 +401,49 @@ global abstract class SOQL implements Comparable {
   }
 
   protected String doGetWhereClauseString() {
-    this.whereFilters.sort();
-    return this.whereFilters.isEmpty() ? '' : ' WHERE ' + String.join(this.whereFilters, ' AND ');
+    List<String> whereFilterStrings = new List<String>();
+    for (QueryFilter filter : this.whereFilters)
+    {
+        filter.setBindKey(filter.getBindKey() ?? this.generateNextBindVariableKey());
+        if (String.isNotBlank(filter.bindKey)) {
+          this.bindsMap.put(filter.bindKey, filter.value);
+        }
+        whereFilterStrings.add(filter.toString());
+    }
+    if (String.isBlank(this.whereFilterConditionsString))
+    {
+        return '';
+    }
+
+    List<String> whereFilterConditionsParts = this.whereFilterConditionsString.split('\\s+');
+    List<String> whereFilterConditionsPartsReplaced = new List<String>();
+    for (String whereFilterConditionsPart : whereFilterConditionsParts)
+    {
+        Matcher m = Pattern.compile('\\d+').matcher(whereFilterConditionsPart);
+        Boolean indexFound = m.find();
+        if (indexFound)
+        {
+            Integer whereFilterConditionsIndex = Integer.valueOf(m.group());
+            try
+            {
+                whereFilterConditionsPartsReplaced.add(
+                    whereFilterConditionsPart.replace(
+                        m.group(),
+                        whereFilterStrings[whereFilterConditionsIndex - 1]
+                    )
+                );
+            }
+            catch (ListException e)
+            {
+                throw new QueryException('No query WHERE filter defined for index "' + whereFilterConditionsIndex + '" specified in filter conditions "' + this.whereFilterConditionsString + '"');
+            }
+        }
+        else
+        {
+            whereFilterConditionsPartsReplaced.add(whereFilterConditionsPart);
+        }
+    }
+    return ' WHERE ' + String.join(whereFilterConditionsPartsReplaced, ' ');
   }
 
   protected System.AccessLevel doGetAccessLevel() {

--- a/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOSL.cls
+++ b/nebula-query-and-search/main/classes/SOSL.cls
@@ -121,6 +121,10 @@ global abstract class SOSL {
     return this.withClauses.isEmpty() ? '' : ' WITH ' + String.join(this.withClauses, ' WITH ');
   }
 
+  protected void doWithAccessLevel(System.AccessLevel accessLevel) {
+    this.accessLevel = accessLevel;
+  }
+
   protected System.AccessLevel doGetAccessLevel() {
     return this.accessLevel ?? System.AccessLevel.SYSTEM_MODE;
   }

--- a/nebula-query-and-search/main/classes/SOSL.cls
+++ b/nebula-query-and-search/main/classes/SOSL.cls
@@ -42,6 +42,7 @@ global abstract class SOSL {
   protected SOSL.ArticleReporting articleReporting;
   protected List<String> withClauses;
   protected List<String> withDataCategoryClauses;
+  protected System.AccessLevel accessLevel;
   protected SOSL.SearchGroup searchGroup;
 
   protected SOSL(String searchTerm, Query sobjectQuery) {
@@ -57,6 +58,7 @@ global abstract class SOSL {
     this.searchGroup = SOSL.SearchGroup.ALL_FIELDS;
     this.withClauses = new List<String>();
     this.withDataCategoryClauses = new List<String>();
+    this.accessLevel = System.AccessLevel.SYSTEM_MODE;
   }
 
   public Set<Schema.SObjectType> getSObjectTypes() {
@@ -88,7 +90,7 @@ global abstract class SOSL {
     if (this.cacheResults) {
       return this.getCachedResults();
     } else {
-      return System.Search.query(this.getSearch());
+      return System.Search.query(this.getSearch(), this.doGetAccessLevel());
     }
   }
 
@@ -119,6 +121,10 @@ global abstract class SOSL {
     return this.withClauses.isEmpty() ? '' : ' WITH ' + String.join(this.withClauses, ' WITH ');
   }
 
+  protected System.AccessLevel doGetAccessLevel() {
+    return this.accessLevel ?? System.AccessLevel.SYSTEM_MODE;
+  }
+
   protected String doGetUpdateArticleReportingString() {
     return this.articleReporting == null ? '' : ' UPDATE ' + this.articleReporting.name();
   }
@@ -129,7 +135,10 @@ global abstract class SOSL {
 
     Boolean isCached = cachedSearchResultsByHashCode.containsKey(hashCode);
     if (!isCached) {
-      cachedSearchResultsByHashCode.put(hashCode, Search.query(searchQuery));
+      cachedSearchResultsByHashCode.put(
+        hashCode,
+        System.Search.query(searchQuery, this.doGetAccessLevel())
+      );
     }
 
     // Always return a deep clone so the original cached version is never modified

--- a/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
+++ b/nebula-query-and-search/main/classes/SOSL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -8,6 +8,35 @@
 )
 @IsTest(IsParallel=true)
 private class AggregateQuery_Tests {
+
+  @IsTest
+  static void it_should_construct_a_count_query_without_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT COUNT() FROM Opportunity WHERE AccountId != null';
+
+    // TEST
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Opportunity.AccountId, SOQL.Operator.NOT_EQUAL_TO, null));
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getCountQuery());
+  }
+
+  @IsTest
+  static void it_should_construct_a_count_query_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT COUNT() FROM Opportunity WHERE AccountId != :accountIdFilter';
+
+    // TEST
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Opportunity.AccountId, SOQL.Operator.NOT_EQUAL_TO, null, 'accountIdFilter'));
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getCountQuery());
+  }
+
   @IsTest
   static void it_should_be_usable_after_construction() {
     String expectedQueryString = 'SELECT COUNT(Id) COUNT__Id FROM Opportunity';
@@ -31,6 +60,53 @@ private class AggregateQuery_Tests {
     System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
     List<Schema.AggregateResult> expectedResults = Database.query(expectedQueryString);
     List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
+  static void it_should_return_count_result_when_filtering_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT COUNT() FROM Opportunity WHERE AccountId != :accountIdFilter';
+    Integer expectedResult = Database.countQueryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'accountIdFilter' => null
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Opportunity.AccountId, SOQL.Operator.NOT_EQUAL_TO, null, 'accountIdFilter'));
+
+    // TEST
+    Integer returnedResult = aggregateQuery.getResultCount();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getCountQuery());
+    System.Assert.areEqual(expectedResult, returnedResult);
+  }
+
+  @IsTest
+  static void it_should_return_results_when_filtering_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Type FROM Opportunity WHERE AccountId != :accountIdFilter GROUP BY Type';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'accountIdFilter' => null
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .groupByField(Schema.Opportunity.Type)
+      .filterWhere(new SOQL.QueryFilter(Schema.Opportunity.AccountId, SOQL.Operator.NOT_EQUAL_TO, null, 'accountIdFilter'));
+
+    // TEST
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
     System.Assert.areEqual(expectedResults, returnedResults);
   }
 
@@ -116,6 +192,31 @@ private class AggregateQuery_Tests {
   }
 
   @IsTest
+  static void it_should_group_by_having_aggregate_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Name, COUNT(Id) COUNT__Id FROM Account GROUP BY Name HAVING COUNT(Id) > :minCount';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'minCount' => 2
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .groupByField(Schema.Account.Name)
+      .addAggregate(SOQL.Aggregate.COUNT, Schema.Account.Id)
+      .havingAggregate(SOQL.Aggregate.COUNT, Schema.Account.Id, SOQL.Operator.GREATER_THAN, 2, 'minCount');
+
+    // TEST
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
   static void it_should_group_by_a_date_function() {
     String expectedQueryString = 'SELECT CALENDAR_MONTH(CloseDate), COUNT(Id) COUNT__Id FROM Opportunity GROUP BY CALENDAR_MONTH(CloseDate)';
 
@@ -182,7 +283,7 @@ private class AggregateQuery_Tests {
       ' COUNT_DISTINCT(AccountId) COUNT_DISTINCT__AccountId, COUNT_DISTINCT(OwnerId) COUNT_DISTINCT__OwnerId, COUNT_DISTINCT(Type) COUNT_DISTINCT__Type,' +
       ' MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate, SUM(Amount) SUM__Amount' +
       ' FROM Opportunity' +
-      ' WHERE AccountId != null' +
+      ' WHERE AccountId != null AND CreatedDate >= :createdDateFilter' +
       ' GROUP BY Account.Type, StageName' +
       ' ORDER BY Account.Type ASC NULLS FIRST, StageName ASC NULLS FIRST, SUM(Amount) ASC NULLS FIRST,' +
       ' MIN(CloseDate) DESC NULLS FIRST, MAX(Account.LastActivityDate) ASC NULLS FIRST' +
@@ -206,13 +307,135 @@ private class AggregateQuery_Tests {
       .orderByAggregate(SOQL.Aggregate.MIN, Schema.Opportunity.CloseDate, SOQL.SortOrder.DESCENDING)
       .orderByAggregate(SOQL.Aggregate.MAX, new SOQL.QueryField(new List<Schema.SObjectField>{ Schema.Opportunity.AccountId, Schema.Account.LastActivityDate }))
       .filterWhere(Schema.Opportunity.AccountId, SOQL.Operator.NOT_EQUAL_TO, null)
+      .filterWhere(Schema.Opportunity.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today(), 'createdDateFilter')
       .limitTo(100)
       .offsetBy(0);
 
     System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
-    List<Schema.AggregateResult> expectedResults = Database.query(expectedQueryString);
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'createdDateFilter' => Date.today()
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
     List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
+  static void it_will_set_a_bind_variable()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= :dateFilter';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'dateFilter' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+
+    // TEST
+    aggregateQuery.setBind('dateFilter', Date.today().addDays(-1));
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse((Date)returnedResults[0].get('MIN__CreatedDate') < Date.today().addDays(-1));
+    }
+  }
+
+  @IsTest
+  static void it_will_set_multiple_bind_variables()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'minDateFilter' => Date.today().addDays(-7),
+        'maxDateFilter' => Date.today()
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .addAggregate(SOQL.Aggregate.MAX, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'));
+
+    // TEST
+    aggregateQuery.setBind('minDateFilter', Date.today().addDays(-7));
+    aggregateQuery.setBind('maxDateFilter', Date.today());
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse((Date)returnedResults[0].get('MIN__CreatedDate') < Date.today().addDays(-7));
+      System.Assert.isFalse((Date)returnedResults[0].get('MAX__CreatedDate') >= Date.today());
+    }
+  }
+
+  @IsTest
+  static void it_will_remove_a_bind_variable()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= :dateFilter';
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+
+    // TEST
+    aggregateQuery.removeBind('dateFilter');
+    Exception caughtException;
+    try {
+      List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+    }
+    catch (Exception e) {
+      caughtException = e;
+    }
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.isInstanceOfType(caughtException, QueryException.class);
+    System.Assert.areEqual('Key \'dateFilter\' does not exist in the bindMap', caughtException.getMessage());
+  }
+
+  @IsTest
+  static void it_will_clear_all_bind_variables()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .addAggregate(SOQL.Aggregate.MAX, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'));
+
+    // TEST
+    aggregateQuery.clearBinds();
+    Exception caughtException;
+    try {
+      List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+    }
+    catch (Exception e) {
+      caughtException = e;
+    }
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.isInstanceOfType(caughtException, QueryException.class);
+    System.Assert.areEqual('Key \'maxDateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   static User minimumAccessUser() {

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -451,4 +451,64 @@ private class AggregateQuery_Tests {
       UserName = 'newuser@testorg.com'
     );
   }
+
+  @IsTest
+  static void it_will_generate_a_bind_variable_for_a_having_filter()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT ParentId, MIN(CreatedDate) MIN__CreatedDate FROM Account GROUP BY ParentId HAVING MIN(CreatedDate) >= :bindVar0';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .groupByField(Account.ParentId)
+      .havingAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1));
+
+    // TEST
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse((Date)returnedResults[0].get('MIN__CreatedDate') < Date.today().addDays(-1));
+    }
+  }
+
+  @IsTest
+  static void it_will_generate_a_bind_variable_for_a_where_filter()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= :bindVar0';
+    List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1)));
+
+    // TEST
+    List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse((Date)returnedResults[0].get('MIN__CreatedDate') < Date.today().addDays(-1));
+    }
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -493,4 +493,52 @@ private class AggregateQuery_Tests {
     }
   }
 
+  @IsTest
+  static void it_will_construct_a_where_clause_based_on_custom_logic()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE (CreatedDate = :bindVar1 OR LastModifiedDate = :bindVar0) AND (Name LIKE :bindVar3 OR Parent.Name LIKE :bindVar2)';
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.LastModifiedDate, SOQL.Operator.EQUALS, Date.today()))
+      .orFilterWhere(
+        new List<SOQL.QueryFilter> {
+          new SOQL.QueryFilter(new SOQL.QueryField(Schema.Account.getSObjectType(), 'Parent.Name'), SOQL.Operator.IS_LIKE, 'Test%'),
+          new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.EQUALS, Date.today().addDays(-1))
+        }
+      )
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.Name, SOQL.Operator.IS_LIKE, 'Smith%'))
+      .setWhereFilterLogic('(2 OR 1) AND (4 OR 3)');
+
+    // TEST
+    String actualQueryString = aggregateQuery.getQuery();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, actualQueryString);
+  }
+
+  @IsTest
+  static void it_will_construct_a_having_clause_based_on_custom_logic()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT COUNT(Id) COUNT__Id, MIN(CreatedDate) MIN__CreatedDate, MIN(LastModifiedDate) MIN__LastModifiedDate FROM Account HAVING (MIN(CreatedDate) = :bindVar2 OR MIN(LastModifiedDate) = :bindVar1) AND (COUNT(Id) = :bindVar3 OR COUNT(Id) = :bindVar0)';
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
+      .addAggregate(SOQL.Aggregate.MIN, Schema.Account.LastModifiedDate)
+      .addAggregate(SOQL.Aggregate.COUNT, Schema.Account.Id)
+      .havingAggregate(SOQL.Aggregate.COUNT, Schema.Account.Id, SOQL.Operator.EQUALS, 10)
+      .havingAggregate(SOQL.Aggregate.MIN, Schema.Account.LastModifiedDate, SOQL.Operator.EQUALS, Datetime.newInstance(2000, 1, 1))
+      .havingAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate, SOQL.Operator.EQUALS, Datetime.newInstance(2021, 12, 31))
+      .havingAggregate(SOQL.Aggregate.COUNT, Schema.Account.Id, SOQL.Operator.EQUALS, 100)
+      .setHavingFilterLogic('(3 OR 2) AND (4 OR 1)');
+
+    // TEST
+    String actualQueryString = aggregateQuery.getQuery();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, actualQueryString);
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -390,52 +390,34 @@ private class AggregateQuery_Tests {
   static void it_will_remove_a_bind_variable()
   {
     // SETUP
-    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= :dateFilter';
+    String expectedQueryString = 'SELECT MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= 2000-01-01T05:00:00Z';
     AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
       .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Datetime.newInstance(2000, 1, 1), 'dateFilter'));
 
     // TEST
     aggregateQuery.removeBind('dateFilter');
-    Exception caughtException;
-    try {
-      List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
-    }
-    catch (Exception e) {
-      caughtException = e;
-    }
 
     // VERIFY
     System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
-    System.Assert.isInstanceOfType(caughtException, QueryException.class);
-    System.Assert.areEqual('Key \'dateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   @IsTest
   static void it_will_clear_all_bind_variables()
   {
     // SETUP
-    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= 2000-01-01T05:00:00Z AND CreatedDate < 2001-01-01T05:00:00Z';
     AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
       .addAggregate(SOQL.Aggregate.MIN, Schema.Account.CreatedDate)
       .addAggregate(SOQL.Aggregate.MAX, Schema.Account.CreatedDate)
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'));
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Datetime.newInstance(2000, 1, 1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Datetime.newInstance(2001, 1, 1), 'maxDateFilter'));
 
     // TEST
     aggregateQuery.clearBinds();
-    Exception caughtException;
-    try {
-      List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
-    }
-    catch (Exception e) {
-      caughtException = e;
-    }
 
     // VERIFY
     System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
-    System.Assert.isInstanceOfType(caughtException, QueryException.class);
-    System.Assert.areEqual('Key \'maxDateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   static User minimumAccessUser() {

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -112,7 +112,7 @@ private class AggregateQuery_Tests {
 
   @IsTest
   static void it_should_return_results_when_filtering_with_an_or_statement() {
-    String expectedQueryString = 'SELECT Type, COUNT(Id) COUNT__Id FROM Account WHERE (AnnualRevenue = null OR Type = null) AND ParentId != null GROUP BY Type';
+    String expectedQueryString = 'SELECT Type, COUNT(Id) COUNT__Id FROM Account WHERE ParentId != null AND (AnnualRevenue = null OR Type = null) GROUP BY Type';
 
     AggregateQuery aggregateQuery = new AggregateQuery(Schema.Account.SObjectType)
       .groupByField(Schema.Account.Type)
@@ -135,13 +135,13 @@ private class AggregateQuery_Tests {
   static void it_should_cache_results() {
     AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType);
     aggregateQuery.cacheResults();
-    System.assertEquals(0, System.Limits.getQueries());
+    System.Assert.areEqual(0, System.Limits.getQueries());
 
     for (Integer i = 0; i < 3; i++) {
       aggregateQuery.getResults();
     }
 
-    System.assertEquals(1, System.Limits.getQueries());
+    System.Assert.areEqual(1, System.Limits.getQueries());
   }
 
   @IsTest
@@ -356,7 +356,7 @@ private class AggregateQuery_Tests {
   static void it_will_set_multiple_bind_variables()
   {
     // SETUP
-    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    String expectedQueryString = 'SELECT MAX(CreatedDate) MAX__CreatedDate, MIN(CreatedDate) MIN__CreatedDate FROM Account WHERE CreatedDate >= :minDateFilter AND CreatedDate < :maxDateFilter';
     List<Schema.AggregateResult> expectedResults = Database.queryWithBinds(
       expectedQueryString,
       new Map<String, Object> {

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls
@@ -130,6 +130,52 @@ private class AggregateQuery_Tests {
   }
 
   @IsTest
+  static void it_should_run_with_system_mode() {
+    String expectedQueryString = 'SELECT COUNT(Id) COUNT__Id FROM Opportunity';
+
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .addAggregate(SOQL.Aggregate.COUNT, Opportunity.Id)
+      .withAccessLevel(System.AccessLevel.SYSTEM_MODE);
+
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    List<Schema.AggregateResult> expectedResults = Database.query(expectedQueryString);
+    List<Schema.AggregateResult> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = aggregateQuery.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isNull(caughtException, 'Query should not throw exception when run in System Mode');
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
+  static void it_should_run_with_user_mode() {
+    String expectedQueryString = 'SELECT COUNT(Id) COUNT__Id FROM Opportunity';
+
+    AggregateQuery aggregateQuery = new AggregateQuery(Schema.Opportunity.SObjectType)
+      .addAggregate(SOQL.Aggregate.COUNT, Opportunity.Id)
+      .withAccessLevel(System.AccessLevel.USER_MODE);
+
+    System.Assert.areEqual(expectedQueryString, aggregateQuery.getQuery());
+    List<Schema.AggregateResult> expectedResults = Database.query(expectedQueryString);
+    List<Schema.AggregateResult> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = aggregateQuery.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isInstanceOfType(caughtException, System.QueryException.class, 'Query should throw exception when run in User Mode');
+    System.Assert.isTrue(caughtException.getMessage().contains('sObject type \'Opportunity\' is not supported'), 'Query should throw exception when run in User Mode');
+  }
+
+  @IsTest
   static void it_should_build_a_ridiculous_query_string() {
     String expectedQueryString =
       'SELECT Account.Type, StageName, AVG(Amount) AVG__Amount, COUNT(AccountId) COUNT__AccountId,' +
@@ -167,5 +213,19 @@ private class AggregateQuery_Tests {
     List<Schema.AggregateResult> expectedResults = Database.query(expectedQueryString);
     List<Schema.AggregateResult> returnedResults = aggregateQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  static User minimumAccessUser() {
+    return new User(
+      Alias = 'newUser',
+      Email = 'newuser@testorg.com',
+      EmailEncodingKey = 'UTF-8',
+      LastName = 'Testing',
+      LanguageLocaleKey = 'en_US',
+      LocaleSidKey = 'en_US',
+      ProfileId = [SELECT Id FROM Profile WHERE Name = 'Minimum Access - Salesforce'].Id,
+      TimeZoneSidKey = 'GMT',
+      UserName = 'newuser@testorg.com'
+    );
   }
 }

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/AggregateQuery_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -8,6 +8,35 @@
 )
 @IsTest(IsParallel=true)
 private class Query_Tests {
+
+  @IsTest
+  static void it_should_construct_a_query_without_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Id, Name FROM Account WHERE CreatedDate >= THIS_MONTH';
+
+    // TEST
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, new SOQL.DateLiteral(SOQL.FixedDateLiteral.THIS_MONTH)));
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+  }
+
+  @IsTest
+  static void it_should_construct_a_query_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Id, Name FROM Account WHERE CreatedDate >= :dateFilter';
+
+    // TEST
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+  }
+
   @IsTest
   static void it_should_return_results_for_a_simple_query() {
     String expectedQueryString = 'SELECT Id, Name FROM Account';
@@ -194,6 +223,29 @@ private class Query_Tests {
   }
 
   @IsTest
+  static void it_should_return_results_when_filtering_with_binds()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Id, Name FROM Account WHERE CreatedDate >= :createdDateFilter';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'createdDateFilter' => Date.today()
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today(), 'createdDateFilter'));
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
   static void it_should_run_with_system_mode() {
     String expectedQueryString = 'SELECT Id, Name FROM Account LIMIT 1';
 
@@ -322,6 +374,123 @@ private class Query_Tests {
     System.assertEquals(1, System.Limits.getQueries());
 
     System.Test.stopTest();
+  }
+
+  @IsTest
+  static void it_will_set_a_bind_variable()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :dateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'dateFilter' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1);
+
+    // TEST
+    accountQuery.setBind('dateFilter', Date.today().addDays(-1));
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
+  @IsTest
+  static void it_will_set_multiple_bind_variables()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'minDateFilter' => Date.today().addDays(-7),
+        'maxDateFilter' => Date.today()
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1);
+
+    // TEST
+    accountQuery.setBind('minDateFilter', Date.today().addDays(-7));
+    accountQuery.setBind('maxDateFilter', Date.today());
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-7));
+      System.Assert.isFalse(returnedResults[0].CreatedDate >= Date.today());
+    }
+  }
+
+  @IsTest
+  static void it_will_remove_a_bind_variable()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :dateFilter';
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+
+    // TEST
+    accountQuery.removeBind('dateFilter');
+    Exception caughtException;
+    try {
+      List<Account> returnedResults = accountQuery.getResults();
+    }
+    catch (Exception e) {
+      caughtException = e;
+    }
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.isInstanceOfType(caughtException, QueryException.class);
+    System.Assert.areEqual('Key \'dateFilter\' does not exist in the bindMap', caughtException.getMessage());
+  }
+
+  @IsTest
+  static void it_will_clear_all_bind_variables()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'));
+
+    // TEST
+    accountQuery.clearBinds();
+    Exception caughtException;
+    try {
+      List<Account> returnedResults = accountQuery.getResults();
+    }
+    catch (Exception e) {
+      caughtException = e;
+    }
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.isInstanceOfType(caughtException, QueryException.class);
+    System.Assert.areEqual('Key \'maxDateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   static User minimumAccessUser() {

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -613,4 +613,36 @@ private class Query_Tests {
     }
   }
 
+  @IsTest
+  static void it_will_generate_a_bind_key_if_removed()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :bindVar0 ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1)
+      .removeBind('dateFilter')
+      .generateBindVariableKeys();
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -506,4 +506,36 @@ private class Query_Tests {
       UserName = 'newuser@testorg.com'
     );
   }
+
+  @IsTest
+  static void it_will_generate_a_bind_variable()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :bindVar0 ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1)))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1);
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -538,4 +538,97 @@ private class Query_Tests {
     }
   }
 
+  @IsTest
+  static void it_will_generate_a_bind_key_when_instructed_before_filter_is_added()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :bindVar0 ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1)))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1);
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
+  @IsTest
+  static void it_will_generate_a_bind_key_when_instructed_after_filter_is_added()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :bindVar0 ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'bindVar0' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1)))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1)
+      .generateBindVariableKeys();
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
+  @IsTest
+  static void it_will_not_generate_a_bind_key_if_already_specified()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :dateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    List<Account> expectedResults = Database.queryWithBinds(
+      expectedQueryString,
+      new Map<String, Object> {
+        'dateFilter' => Date.today().addDays(-1)
+      },
+      System.AccessLevel.SYSTEM_MODE
+    );
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .addField(Schema.Account.CreatedDate)
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'))
+      .orderByField(Schema.Account.CreatedDate, SOQL.SortOrder.ASCENDING)
+      .limitTo(1)
+      .generateBindVariableKeys();
+
+    // TEST
+    List<Account> returnedResults = accountQuery.getResults();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedResults, returnedResults);
+    if (!returnedResults.isEmpty())
+    {
+      System.Assert.isFalse(returnedResults[0].CreatedDate < Date.today().addDays(-1));
+    }
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -43,7 +43,7 @@ private class Query_Tests {
 
     Query simpleAccountQuery = new Query(Schema.Account.SObjectType);
 
-    System.assertEquals(expectedQueryString, simpleAccountQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, simpleAccountQuery.getQuery());
     List<Account> accounts = simpleAccountQuery.getResults();
   }
 
@@ -65,15 +65,15 @@ private class Query_Tests {
     String expectedQueryString =
       'SELECT Alias, Email, Id, IsActive, Profile.Name, ProfileId' +
       ' FROM User USING SCOPE MINE' +
-      ' WHERE CreatedDate <= LAST_WEEK' +
-      ' AND Email != null' +
-      ' AND IsActive = true' +
-      ' AND LastLoginDate >= LAST_N_DAYS:3' +
-      ' AND LastModifiedDate <= ' +
-      now.format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'', 'Greenwich Mean Time') +
+      ' WHERE IsActive = true' +
       ' AND Profile.Id != \'' +
       System.UserInfo.getProfileId() +
       '\'' +
+      ' AND LastModifiedDate <= ' +
+      now.format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'', 'Greenwich Mean Time') +
+      ' AND LastLoginDate >= LAST_N_DAYS:3' +
+      ' AND CreatedDate <= LAST_WEEK' +
+      ' AND Email != null' +
       ' ORDER BY Profile.CreatedBy.LastModifiedDate ASC NULLS FIRST, Name ASC NULLS FIRST, Email ASC NULLS FIRST' +
       ' LIMIT 100 OFFSET 1 FOR VIEW';
     List<Schema.SObjectField> fieldsToQuery = new List<Schema.SObjectField>{ Schema.User.IsActive, Schema.User.Alias };
@@ -100,7 +100,7 @@ private class Query_Tests {
       .offsetBy(1)
       .forView();
 
-    System.assertEquals(expectedQueryString, userQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, userQuery.getQuery());
     List<User> expectedResults = Database.query(expectedQueryString);
     List<User> returnedResults = userQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -118,7 +118,7 @@ private class Query_Tests {
 
     Query userQuery = new Query(Schema.User.SObjectType).addField(queryField).limitTo(1);
 
-    System.assertEquals(expectedQueryString, userQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, userQuery.getQuery());
     List<User> expectedResults = Database.query(expectedQueryString);
     List<User> returnedResults = userQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -130,7 +130,7 @@ private class Query_Tests {
 
     Query accountQuery = new Query(Schema.Account.SObjectType).addField(new SOQL.QueryField(Schema.Account.OwnerId));
 
-    System.assertEquals(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
     List<Account> accounts = accountQuery.getResults();
   }
 
@@ -176,7 +176,7 @@ private class Query_Tests {
 
     System.Test.stopTest();
 
-    System.assertEquals(expectedQuery, taskQuery.getQuery());
+    System.Assert.areEqual(expectedQuery, taskQuery.getQuery());
   }
 
   @IsTest
@@ -185,7 +185,7 @@ private class Query_Tests {
 
     Query leadQuery = new Query(Schema.Lead.SObjectType).addField(new SOQL.QueryField(Schema.Lead.OwnerId));
 
-    System.assertEquals(expectedQueryString, leadQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, leadQuery.getQuery());
     List<Lead> expectedResults = Database.query(expectedQueryString);
     List<Lead> returnedResults = leadQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -201,7 +201,7 @@ private class Query_Tests {
       .includeRelatedRecords(Schema.Contact.AccountId, contactQuery)
       .addField(new SOQL.QueryField(Schema.Account.Type));
 
-    System.assertEquals(expectedQueryString, accountQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
     List<Account> accounts = accountQuery.getResults();
   }
 
@@ -297,7 +297,7 @@ private class Query_Tests {
 
     Query leadQuery = new Query(Schema.Lead.SObjectType).orderByField(Schema.Lead.CreatedDate);
 
-    System.assertEquals(expectedQueryString, leadQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, leadQuery.getQuery());
     List<Lead> expectedResults = Database.query(expectedQueryString);
     List<Lead> returnedResults = leadQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -309,7 +309,7 @@ private class Query_Tests {
 
     Query leadQuery = new Query(Schema.Lead.SObjectType).forReference();
 
-    System.assertEquals(expectedQueryString, leadQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, leadQuery.getQuery());
     List<Lead> expectedResults = Database.query(expectedQueryString);
     List<Lead> returnedResults = leadQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -321,7 +321,7 @@ private class Query_Tests {
 
     Query leadQuery = new Query(Schema.Lead.SObjectType).forUpdate();
 
-    System.assertEquals(expectedQueryString, leadQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, leadQuery.getQuery());
     List<Lead> expectedResults = Database.query(expectedQueryString);
     List<Lead> returnedResults = leadQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -333,7 +333,7 @@ private class Query_Tests {
 
     Query leadQuery = new Query(Schema.Lead.SObjectType).forView();
 
-    System.assertEquals(expectedQueryString, leadQuery.getQuery());
+    System.Assert.areEqual(expectedQueryString, leadQuery.getQuery());
     List<Lead> expectedResults = Database.query(expectedQueryString);
     List<Lead> returnedResults = leadQuery.getResults();
     System.Assert.areEqual(expectedResults, returnedResults);
@@ -359,11 +359,11 @@ private class Query_Tests {
     Query userQuery = new Query(Schema.User.SObjectType).limitTo(1);
 
     // First, verify that caching is not enabled by default
-    System.assertEquals(0, System.Limits.getQueries());
+    System.Assert.areEqual(0, System.Limits.getQueries());
     for (Integer i = 0; i < loops; i++) {
       userQuery.getResults();
     }
-    System.assertEquals(loops, System.Limits.getQueries());
+    System.Assert.areEqual(loops, System.Limits.getQueries());
 
     System.Test.startTest();
 
@@ -371,13 +371,13 @@ private class Query_Tests {
     for (Integer i = 0; i < loops; i++) {
       userQuery.getResults();
     }
-    System.assertEquals(1, System.Limits.getQueries());
+    System.Assert.areEqual(1, System.Limits.getQueries());
 
     System.Test.stopTest();
   }
 
   @IsTest
-  static void it_will_set_a_bind_variable()
+  static void it_will_set_a_bind_key()
   {
     // SETUP
     String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :dateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
@@ -408,10 +408,10 @@ private class Query_Tests {
   }
 
   @IsTest
-  static void it_will_set_multiple_bind_variables()
+  static void it_will_set_multiple_bind_keys()
   {
     // SETUP
-    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :minDateFilter AND CreatedDate < :maxDateFilter ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';
     List<Account> expectedResults = Database.queryWithBinds(
       expectedQueryString,
       new Map<String, Object> {
@@ -490,7 +490,7 @@ private class Query_Tests {
   }
 
   @IsTest
-  static void it_will_generate_a_bind_variable()
+  static void it_will_generate_a_bind_key()
   {
     // SETUP
     String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :bindVar0 ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1';

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -645,4 +645,28 @@ private class Query_Tests {
     }
   }
 
+  @IsTest
+  static void it_will_construct_a_where_clause_based_on_custom_logic()
+  {
+    // SETUP
+    String expectedQueryString = 'SELECT Id, Name FROM Account WHERE (CreatedDate = :bindVar1 OR LastModifiedDate = :bindVar0) AND (Name LIKE :bindVar3 OR Parent.Name LIKE :bindVar2)';
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .generateBindVariableKeys()
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.LastModifiedDate, SOQL.Operator.EQUALS, Date.today()))
+      .orFilterWhere(
+        new List<SOQL.QueryFilter> {
+          new SOQL.QueryFilter(new SOQL.QueryField(Schema.Account.getSObjectType(), 'Parent.Name'), SOQL.Operator.IS_LIKE, 'Test%'),
+          new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.EQUALS, Date.today().addDays(-1))
+        }
+      )
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.Name, SOQL.Operator.IS_LIKE, 'Smith%'))
+      .setWhereFilterLogic('(2 OR 1) AND (4 OR 3)');
+
+    // TEST
+    String actualQueryString = accountQuery.getQuery();
+
+    // VERIFY
+    System.Assert.areEqual(expectedQueryString, actualQueryString);
+  }
+
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -194,6 +194,52 @@ private class Query_Tests {
   }
 
   @IsTest
+  static void it_should_run_with_system_mode() {
+    String expectedQueryString = 'SELECT Id, Name FROM Account LIMIT 1';
+
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .limitTo(1)
+      .withAccessLevel(System.AccessLevel.SYSTEM_MODE);
+
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    List<Account> expectedResults = Database.query(expectedQueryString);
+    List<Account> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = accountQuery.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isNull(caughtException, 'Query should not throw exception when run in System Mode');
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
+  static void it_should_run_with_user_mode() {
+    String expectedQueryString = 'SELECT Id, Name FROM Account LIMIT 1';
+
+    Query accountQuery = new Query(Schema.Account.SObjectType)
+      .limitTo(1)
+      .withAccessLevel(System.AccessLevel.USER_MODE);
+
+    System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
+    List<Account> expectedResults = Database.query(expectedQueryString);
+    List<Account> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = accountQuery.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isInstanceOfType(caughtException, System.QueryException.class, 'Query should throw exception when run in User Mode');
+    System.Assert.isTrue(caughtException.getMessage().contains('sObject type \'Account\' is not supported'), 'Query should throw exception when run in User Mode');
+  }
+
+  @IsTest
   static void it_includes_order_by_statement_for_single_field() {
     String expectedQueryString = 'SELECT Id, Name FROM Lead ORDER BY CreatedDate ASC NULLS FIRST';
 
@@ -276,5 +322,19 @@ private class Query_Tests {
     System.assertEquals(1, System.Limits.getQueries());
 
     System.Test.stopTest();
+  }
+
+  static User minimumAccessUser() {
+    return new User(
+      Alias = 'newUser',
+      Email = 'newuser@testorg.com',
+      EmailEncodingKey = 'UTF-8',
+      LastName = 'Testing',
+      LanguageLocaleKey = 'en_US',
+      LocaleSidKey = 'en_US',
+      ProfileId = [SELECT Id FROM Profile WHERE Name = 'Minimum Access - Salesforce'].Id,
+      TimeZoneSidKey = 'GMT',
+      UserName = 'newuser@testorg.com'
+    );
   }
 }

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls
@@ -443,54 +443,36 @@ private class Query_Tests {
   }
 
   @IsTest
-  static void it_will_remove_a_bind_variable()
+  static void it_will_remove_a_bind_key()
   {
     // SETUP
-    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= :dateFilter';
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= 2000-01-01T05:00:00Z';
     Query accountQuery = new Query(Schema.Account.SObjectType)
       .addField(Schema.Account.CreatedDate)
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'dateFilter'));
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Datetime.newInstance(2000, 1, 1), 'dateFilter'));
 
     // TEST
     accountQuery.removeBind('dateFilter');
-    Exception caughtException;
-    try {
-      List<Account> returnedResults = accountQuery.getResults();
-    }
-    catch (Exception e) {
-      caughtException = e;
-    }
 
     // VERIFY
     System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
-    System.Assert.isInstanceOfType(caughtException, QueryException.class);
-    System.Assert.areEqual('Key \'dateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   @IsTest
-  static void it_will_clear_all_bind_variables()
+  static void it_will_clear_all_bind_keys()
   {
     // SETUP
-    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate < :maxDateFilter AND CreatedDate >= :minDateFilter';
+    String expectedQueryString = 'SELECT CreatedDate, Id, Name FROM Account WHERE CreatedDate >= 2000-01-01T05:00:00Z AND CreatedDate < 2001-01-01T05:00:00Z';
     Query accountQuery = new Query(Schema.Account.SObjectType)
       .addField(Schema.Account.CreatedDate)
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Date.today().addMonths(-1), 'minDateFilter'))
-      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Date.today().addDays(-1), 'maxDateFilter'));
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.GREATER_THAN_OR_EQUAL_TO, Datetime.newInstance(2000, 1, 1), 'minDateFilter'))
+      .filterWhere(new SOQL.QueryFilter(Schema.Account.CreatedDate, SOQL.Operator.LESS_THAN, Datetime.newInstance(2001, 1, 1), 'maxDateFilter'));
 
     // TEST
     accountQuery.clearBinds();
-    Exception caughtException;
-    try {
-      List<Account> returnedResults = accountQuery.getResults();
-    }
-    catch (Exception e) {
-      caughtException = e;
-    }
 
     // VERIFY
     System.Assert.areEqual(expectedQueryString, accountQuery.getQuery());
-    System.Assert.isInstanceOfType(caughtException, QueryException.class);
-    System.Assert.areEqual('Key \'maxDateFilter\' does not exist in the bindMap', caughtException.getMessage());
   }
 
   static User minimumAccessUser() {

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/Query_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls
+++ b/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls
@@ -128,6 +128,56 @@ private class RecordSearch_Tests {
   }
 
   @IsTest
+  static void it_should_run_with_system_mode() {
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING Contact(Id, Name)';
+
+    Query contactQuery = new Query(Schema.Contact.SObjectType);
+    RecordSearch contactSearch = new RecordSearch(System.UserInfo.getUserEmail(), contactQuery)
+      .withAccessLevel(System.AccessLevel.SYSTEM_MODE);
+
+    System.assertEquals(expectedSearchQueryString, contactSearch.getSearch());
+    List<Contact> contactSearchResults = contactSearch.getFirstResults();
+
+    List<List<SObject>> expectedResults = Search.query(expectedSearchQueryString);
+    List<List<SObject>> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = contactSearch.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isNull(caughtException, 'Search should not throw exception when run in System Mode');
+    System.Assert.areEqual(expectedResults, returnedResults);
+  }
+
+  @IsTest
+  static void it_should_run_with_user_mode() {
+    String expectedSearchQueryString = 'FIND \'' + System.UserInfo.getUserEmail() + '\' IN ALL FIELDS RETURNING Contact(Id, Name)';
+
+    Query contactQuery = new Query(Schema.Contact.SObjectType);
+    RecordSearch contactSearch = new RecordSearch(System.UserInfo.getUserEmail(), contactQuery)
+      .withAccessLevel(System.AccessLevel.USER_MODE);
+
+    System.assertEquals(expectedSearchQueryString, contactSearch.getSearch());
+    List<Contact> contactSearchResults = contactSearch.getFirstResults();
+
+    List<List<SObject>> expectedResults = Search.query(expectedSearchQueryString);
+    List<List<SObject>> returnedResults;
+    Exception caughtException;
+    System.runAs(minimumAccessUser()) {
+        try {
+            returnedResults = contactSearch.getResults();
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+    System.Assert.isInstanceOfType(caughtException, System.QueryException.class, 'Search should throw exception when run in User Mode');
+    System.Assert.isTrue(caughtException.getMessage().contains('sObject type \'contact\' is not supported'), 'Search should throw exception when run in User Mode');
+  }
+
+  @IsTest
   static void it_should_cache_search_results_when_enabled() {
     Integer loops = 4;
     Query userQuery = new Query(Schema.User.SObjectType);
@@ -149,5 +199,19 @@ private class RecordSearch_Tests {
     System.assertEquals(1, System.Limits.getSoslQueries());
 
     System.Test.stopTest();
+  }
+
+  static User minimumAccessUser() {
+    return new User(
+      Alias = 'newUser',
+      Email = 'newuser@testorg.com',
+      EmailEncodingKey = 'UTF-8',
+      LastName = 'Testing',
+      LanguageLocaleKey = 'en_US',
+      LocaleSidKey = 'en_US',
+      ProfileId = [SELECT Id FROM Profile WHERE Name = 'Minimum Access - Salesforce'].Id,
+      TimeZoneSidKey = 'GMT',
+      UserName = 'newuser@testorg.com'
+    );
   }
 }

--- a/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
+++ b/nebula-query-and-search/tests/classes/RecordSearch_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,7 +2,7 @@
   "name": "Nebula Query & Search",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "58.0",
+  "sourceApiVersion": "60.0",
   "plugins": {
     "sfdx-plugin-prettier": {
       "enabled": true

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,7 +2,7 @@
   "name": "Nebula Query & Search",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "60.0",
+  "sourceApiVersion": "61.0",
   "plugins": {
     "sfdx-plugin-prettier": {
       "enabled": true


### PR DESCRIPTION
Adds ability to auto-generate bind variable keys by invoking new `generateBindVariableKeys` method on an `AggregateQuery` or `Query` instance. Extends updates made in PR #49. 

As a nice consequence of changes made, also adds ability to specify custom filter logic.

Query filters are now stored as a list of QueryFilter instances instead of Strings, allowing for the ability to invoke 'generateBindVariableKeys' at any point. Consequently, filter logic is now explicitly defined and used at the time of overall filter string generation rather than being included at the time a filter is added to the Query.

NOTE -- due to the change in the way the overall filter string in constructed I had to remove the overall sorting of the filters, but did leave the sorting of "OR" filters since that doesn't interfere. If the sorting is important to keep, a different approach to filter structure and logic would need to be taken to allow for it.